### PR TITLE
Issue #19 - bug: nav menu doesn't persist on page when scrolling

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1,6 +1,9 @@
 /* header and nav layout */
 header {
   height: 12.5rem;
+  position: fixed;
+  top: 0;
+  width: 100%;
 }
 
 .nav-wrapper {
@@ -11,11 +14,18 @@ header {
   margin: 0 auto;
 }
 
-.nav-logo {
-  left: 1.0rem;
+.nav-logo-big {
+  left: 1.85rem;
   position: absolute;
-  bottom: 1.0rem;
-  width: 17.6rem;
+  bottom: 1.85rem;
+  width: 17.4rem;
+}
+
+.nav-logo-small {
+  left: 1.8rem;
+  position: absolute;
+  bottom: 3.5rem;
+  width: 3.5rem;
 }
 
 header nav {
@@ -146,9 +156,14 @@ header nav[aria-expanded="true"] .nav-hamburger-icon::after {
   }
 }
 
-/* Nav menu container housing both the sections and tools menu rows */
-#nav {
+/* Nav menu container housing both the sections and tools menu rows when expanded */
+#nav.nav-big{
   padding: 1.2rem 2rem 0 25rem;
+}
+
+/* Nav menu container housing both the sections and tools menu rows when expanded */
+#nav.nav-small{
+  padding: 1.2rem 2rem 0 10.5rem;
 }
 
 /* Lower sections menu item container */
@@ -177,6 +192,8 @@ nav[aria-expanded="true"] .nav-sections {
   transform: rotate(135deg);
   width: 6px;
   height: 6px;
+  border-style: solid;
+  border-color: currentcolor;
   border-radius: 0 1px 0 0;
   border-width: 2px 2px 0 0;
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -3,6 +3,31 @@ import { getMetadata, decorateIcons } from '../../scripts/lib-franklin.js';
 // media query match that indicates mobile/tablet width
 const isDesktop = window.matchMedia('(min-width: 900px)');
 
+// Add a scroll listener in order to handle transforming the nav on scroll down
+window.onscroll = function() {
+  scrollFunction()
+};
+
+let oldScrollY = window.scrollY;
+// Scroll event listener to handle transforming the nav bar from big to small when scrolling down after a certain threshold (160 px) and on any scroll up event
+function scrollFunction() {
+  const scrollDistance = 160;
+  const newScrollY = window.scrollY;
+  const scrolledDown = (oldScrollY - newScrollY < 0);
+  if (scrolledDown && document.body.scrollTop > scrollDistance || scrolledDown && document.documentElement.scrollTop > scrollDistance) {
+    document.getElementById('nav').querySelector('.nav-tools').style.display = 'none';
+    document.getElementById('nav').classList.replace('nav-big','nav-small');
+    document.getElementById('brand-logo-big').style.display = 'none';
+    document.getElementById('brand-logo-small').style.display = '';
+
+  } else {
+    document.getElementById('nav').querySelector('.nav-tools').style.display = 'flex';
+    document.getElementById('nav').classList.replace('nav-small','nav-big');
+    document.getElementById('brand-logo-small').style.display = 'none';
+    document.getElementById('brand-logo-big').style.display = '';
+  }
+  oldScrollY = newScrollY;
+}
 function closeOnEscape(e) {
   if (e.code === 'Escape') {
     const nav = document.getElementById('nav');
@@ -95,7 +120,8 @@ function buildLogo() {
   logo.classList.add('nav-logo');
   logo.innerHTML = `
       <a href="/" rel="noopener">
-        <img alt="Vonage" class="nav-logo" src="/icons/vonage-nav-logo-black.svg" loading="lazy"/>
+        <img id="brand-logo-big" alt="Vonage" class="nav-logo-big" src="/icons/vonage-nav-logo-black.svg" loading="lazy"/>
+        <img id="brand-logo-small" alt="Vonage" class="nav-logo-small" src="/icons/vonage-v-logo-black.svg" loading="lazy" style="display:none;"/>
       </a>
     `;
   return logo;
@@ -117,6 +143,7 @@ export default async function decorate(block) {
     // decorate nav DOM
     const nav = document.createElement('nav');
     nav.id = 'nav';
+    nav.classList.add('nav-big')
     nav.innerHTML = html;
 
     const classes = ['sections', 'tools'];

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -3,31 +3,30 @@ import { getMetadata, decorateIcons } from '../../scripts/lib-franklin.js';
 // media query match that indicates mobile/tablet width
 const isDesktop = window.matchMedia('(min-width: 900px)');
 
-// Add a scroll listener in order to handle transforming the nav on scroll down
-window.onscroll = function() {
-  scrollFunction()
-};
-
+/* Scroll event listener to handle transforming the nav bar from big to small
+   when scrolling down after a certain threshold (160 px) and on any scroll up event */
 let oldScrollY = window.scrollY;
-// Scroll event listener to handle transforming the nav bar from big to small when scrolling down after a certain threshold (160 px) and on any scroll up event
 function scrollFunction() {
   const scrollDistance = 160;
   const newScrollY = window.scrollY;
   const scrolledDown = (oldScrollY - newScrollY < 0);
-  if (scrolledDown && document.body.scrollTop > scrollDistance || scrolledDown && document.documentElement.scrollTop > scrollDistance) {
+  if ((scrolledDown && document.body.scrollTop > scrollDistance)
+   || (scrolledDown && document.documentElement.scrollTop > scrollDistance)) {
     document.getElementById('nav').querySelector('.nav-tools').style.display = 'none';
-    document.getElementById('nav').classList.replace('nav-big','nav-small');
+    document.getElementById('nav').classList.replace('nav-big', 'nav-small');
     document.getElementById('brand-logo-big').style.display = 'none';
     document.getElementById('brand-logo-small').style.display = '';
-
   } else {
     document.getElementById('nav').querySelector('.nav-tools').style.display = 'flex';
-    document.getElementById('nav').classList.replace('nav-small','nav-big');
+    document.getElementById('nav').classList.replace('nav-small', 'nav-big');
     document.getElementById('brand-logo-small').style.display = 'none';
     document.getElementById('brand-logo-big').style.display = '';
   }
   oldScrollY = newScrollY;
 }
+// Add a scroll listener in order to handle transforming the nav on scroll down
+window.onscroll = scrollFunction;
+
 function closeOnEscape(e) {
   if (e.code === 'Escape') {
     const nav = document.getElementById('nav');
@@ -143,7 +142,7 @@ export default async function decorate(block) {
     // decorate nav DOM
     const nav = document.createElement('nav');
     nav.id = 'nav';
-    nav.classList.add('nav-big')
+    nav.classList.add('nav-big');
     nav.innerHTML = html;
 
     const classes = ['sections', 'tools'];
@@ -157,7 +156,9 @@ export default async function decorate(block) {
     const navSections = nav.querySelector('.nav-sections');
     if (navSections) {
       navSections.querySelectorAll(':scope > ul > li').forEach((navSection) => {
-        if (navSection.querySelector('ul')) navSection.classList.add('nav-drop');
+        if (navSection.querySelector('ul')) {
+          navSection.classList.add('nav-drop');
+        }
         navSection.addEventListener('click', () => {
           if (isDesktop.matches) {
             const expanded = navSection.getAttribute('aria-expanded') === 'true';


### PR DESCRIPTION
Fix #19 

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/
- After: https://issue-19-nav-scrolling-bug--vonage--hlxsites.hlx.page/unified-communications/

Changes:
- Nav menu is now 'sticky' and will remain at the top of the page when scrolled
- Nav menu now collapses the upper tools section and swaps to a smaller logo on scroll down of a sufficient length (160 pixels) and reverts immediately on any scroll up event
- Also addresses a mistake I missed where the nav-drop decorations border property was nixed resulting in the little chevrons for the drop down nav menus no longer rendering.

This is currently lacking a transition / delay on the transform as the clients own site does (a quarter second), so might want to come back and implement that later but for now struggled to get it working and not going to stop for now to chase that down.