### PR TITLE
issue-64 Change info-card flex direction to fix vertical alignment.

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -316,10 +316,8 @@
     padding-right: 20px;
     cursor: pointer;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     height: 100%;
-    -ms-flex-pack: end;
-    justify-content: flex-end;
     min-height: 31.9rem;
     position: relative;
   }
@@ -336,8 +334,6 @@
     cursor: pointer;
     display: flex;
     flex-direction: column;
-    -ms-flex-pack: end;
-    justify-content: flex-end;
     min-height: 31.9rem;
     padding: 4rem;
   }


### PR DESCRIPTION
Changed flex direction for info-cards to make both elements in the row stretch to the same height.

Fix #64

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/features/admin-portal
- After: https://issue-64-info-card-vertical--vonage--hlxsites.hlx.page/unified-communications/features/admin-portal
