### PR TITLE
Issue 5 subnav

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -390,7 +390,6 @@
     letter-spacing: -.025rem;
     line-height: 2.5rem;
     font-weight: 400;
-    -moz-osx-font-smoothing: grayscale;
   }
 
   /* Styling of the arrow icon and it's animation */

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -909,3 +909,214 @@ header .sub-menu-label-active {
       top:-1.1rem;
     }
 }
+
+
+header .nav-breadcrumb-wrapper {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 5.2rem;
+  padding: 0 34px 5px;
+  position: relative;
+  background: #fbfbfb 0 0 no-repeat padding-box;
+  font-size: 1.3rem;
+  font-weight: 500;
+  font-family: Spezia;
+  padding-top: 10px;
+  background: #fbfbfb;
+  background: -webkit-gradient(linear,left bottom,left top,color-stop(85%,#fbfbfb),to(#efefef));
+  background: linear-gradient(0deg,#fbfbfb 85%,#efefef);
+  border-bottom: 1px solid #ddd;
+}
+
+.container.section-container {
+  display: flex;
+  box-sizing: border-box;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.left-sec {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  align-items: center;
+}
+
+.right-sec {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  align-items: center;
+}
+
+.right-sec__menu-option {
+  margin-right: 4rem;
+  cursor: pointer;
+}
+
+.l3-nav__menu-title {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 1.5rem;
+  min-width: 8rem;
+  cursor: pointer;
+}
+
+span.title-option {
+  margin-right: 1.5rem;
+  color: #000;
+}
+
+a.title-option__l3nav {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #717171;
+}
+
+a.title-option__l3nav.active {
+  color: #000;
+}
+
+span.nav-icon.Vlt-icon-phone {
+  color: #000;
+  padding-right: 10px;
+  font-size: 1.5rem;
+  font-family: VltIcons!important;
+  font-style: normal;
+  font-variant: normal;
+  font-weight: 400;
+  line-height: inherit;
+  speak: none;
+  text-transform: none;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+span.nav-icon.Vlt-icon-phone::before {
+  content: "\e939";
+}
+
+span.Vlt-icon-chevron.arrow-icn {
+  display: inline-block;
+  font-size: 2rem;
+  position: relative;
+  -webkit-transform: rotate(0deg);
+  transform: rotate(0deg);
+  color: #881fff;
+}
+
+span.Vlt-icon-chevron.arrow-icn::before {
+  content: "\e90d";
+}
+
+a.title-option {
+  text-decoration: none;
+  color: #000;
+}
+
+.menu-option-sublist.l3-nav__menu-options {
+  opacity: 0;
+  visibility: hidden;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 5rem;
+  padding: 0 34px 17px;
+  max-height: 40rem;
+  overflow-y: auto;
+  -ms-scroll-chaining: none;
+  overscroll-behavior: contain;
+  background: #fbfbfb 0 0 no-repeat padding-box;
+  border-bottom: 1px solid #ddd;
+}
+
+.menu-option-sublist.l3-nav__menu-options.active {
+  opacity:100;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  visibility: visible;
+  z-index: 4;
+  -webkit-animation: fadein .75s forwards;
+  animation: fadein .75s forwards;
+}
+
+.container.sublist-container {
+  display: flex;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px;
+}
+
+.list.l3-nav__menu-options--list.first {
+  padding-left: 25px;
+}
+
+.list.l3-nav__menu-options--list {
+  min-width: 8rem;
+  margin-right: 1.5rem;
+}
+
+.l3-nav__menu-options--list ul {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}
+
+.l3-nav__menu-options--list li {
+  cursor: pointer;
+  min-height: 1rem;
+  margin-bottom: 1rem;
+}
+
+.l3-nav__menu-options--list ul li a{
+  color: #717171;
+  font-size: 1.25rem;
+  font-weight: 400;
+}
+
+@media (min-width: 576px) {
+  .container.section-container, .container.sublist-container {
+    max-width: 540px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container.section-container, .container.sublist-container {
+    max-width: 45pc;
+  }
+}
+
+@media (min-width: 992px) {
+  .container.section-container, .container.sublist-container {
+    max-width: 990pt;
+  }
+}
+
+

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1103,7 +1103,7 @@ a.title-option__l3nav:hover {
   box-sizing: border-box;
 }
 
-.l3-nav__menu-title:last-child .title-option__l3nav {
+.l3-nav__menu-title .title-option__l3nav.boldbreadCrumbTitle {
   font-weight: 600;
   color: #000;
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -56,17 +56,16 @@ header .nav-wrapper {
   position: relative;
   max-width: 132rem;
   margin: 0 auto;
-  height: var(--nav-height);
 }
 
 /* Styling for the div container that holds the two versions of the logo image */
 header .nav-logo {
   position: absolute;
-  top: 3.2rem;
-  width: 14.6rem;
-  height: auto;
-  left: 0.2rem;
-  transition: opacity .36s ease-in-out,transform .36s ease-in-out,-webkit-transform .36s ease-in-out;
+  color: #000;
+  left: 2rem;
+  top: 2.2rem;
+  width: 10.2rem;
+  z-index: 7;
 }
 
 /* Styling of the full logo image displayed in desktop mode before scrolling down as well as mobile */
@@ -124,7 +123,7 @@ header .nav-sections > ul, header .nav-tools > ul, header .nav-search > ul {
 header .nav-search {
   position: absolute;
   height: 2.4rem;
-  top: 3.6rem;
+  top: 2.4rem;
   width: 2.4rem;
   right: 6rem;
 }
@@ -183,13 +182,18 @@ header .nav-sections .nav-drop::after {
   }
 
   /*  Styles relating to the 'hamburger' menu button */
-  header #nav .nav-hamburger {
-    position: absolute;
-    height: 2.4rem;
-    top: 3.6rem;
-    width: 2.4rem;
-    right: 2rem;
-  }
+header #nav .nav-hamburger {
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  height: 1.8rem;
+  padding: 0;
+  position: absolute;
+  right: 2rem;
+  top: 2.8rem;
+  width: 1.8rem;
+  z-index: 7;
+}
 
   header #nav .nav-hamburger button {
     margin: 0;
@@ -213,7 +217,7 @@ header .nav-sections .nav-drop::after {
   header #nav .nav-hamburger-icon::before,
   header #nav .nav-hamburger-icon::after {
     display: block;
-    width: 2.4rem;
+    width: 100%;
     height: 2.4rem;
   }
 
@@ -472,6 +476,8 @@ header #nav .nav-sections > ul > div > li > strong > a {
   margin: 0;
   font-size: 1.5rem;
   display: inline-block;
+  color: #000;
+  background-color: #FFF;
 }
 
 header #nav .nav-sections > ul > div > li > strong > a:hover {
@@ -488,6 +494,8 @@ header #nav .nav-sections > ul > div > li > em > a {
   border: 1px solid black;
   border-radius: 1rem;
   margin-left: auto;
+  color: #000;
+  background-color: #FFF;
 }
 
 header #nav .nav-sections > ul > div > li > em > a:hover {
@@ -549,7 +557,7 @@ header .sub-menu-label-active {
     }
 
     header .nav-logo-small {
-      color: var(--nav-logo-color);;
+      color: var(--nav-logo-color);
       left: 1.8rem;
       position: absolute;
       width: 3.5rem;
@@ -634,33 +642,31 @@ header .sub-menu-label-active {
       cursor: pointer;
     }
 
-    /* Make the last item of the sections nav the 'Contact us' button in black and aligned to the right */
+  header #nav .nav-sections > ul > div > li > em > a {
+    display: inline-block;
+    font-size: 1.5rem;
+    height: 4.5rem;
+    line-height: 4.5rem;
+    padding-left: 2rem;
+    padding-right: 2rem;
+    border: 1px solid black;
+    border-radius: 1rem;
+    margin-left: auto;
+  }
 
-    /* header #nav .nav-sections > ul > div:last-child { */
-
-    /*  margin: auto 0 auto auto; */
-
-    /*  height:4.5rem; */
-
-    /* } */
-
-    /* header #nav .nav-sections > ul > div:last-child > li { */
-
-    /*  border-radius: 1rem; */
-
-    /*  color: var(--nav-contact-button-color); */
-
-    /*  background-color: var(--nav-contact-button-background-color); */
-
-    /*  height: 4.5rem; */
-
-    /*  line-height: 4.5rem; */
-
-    /*  font-size: 1.5rem; */
-
-    /*  margin: 0; */
-
-    /* } */
+  /* Primary CTA button styling in the header */
+  header #nav .nav-sections > ul > div > li > strong > a {
+    border-radius: 1rem;
+    color: var(--nav-contact-button-color);
+    background-color: var(--nav-contact-button-background-color);
+    height: 4.5rem;
+    line-height: 4.5rem;
+    padding-left: 2rem;
+    padding-right: 2rem;
+    margin: 0;
+    font-size: 1.5rem;
+    display: inline-block;
+  }
 
   .nav-item-wrapper.cta li {
     margin-left: 0;
@@ -959,7 +965,6 @@ header .sub-menu-label-active {
 
 header .l3-nav__desktop {
   display: -webkit-box;
-  display: flexbox;
   display: flex;
   box-sizing: border-box;
   -webkit-box-pack: justify;
@@ -1147,9 +1152,33 @@ a.title-option__l3nav:hover {
   box-sizing: border-box;
 }
 
+.l3-nav__mobile--closed.not-active, .l3-nav__mobile--open.not-active {
+  display: none;
+}
+
 .l3-nav__menu-title .title-option__l3nav.boldbreadCrumbTitle {
   font-weight: 600;
   color: #000;
+}
+
+.l3-nav__mobile--menu-body .menu-sub-list ul li a.bold {
+  font-weight: 500;
+  color: #000;
+}
+
+.l3-nav__mobile--menu-body .title-item:hover {
+  text-decoration: none;
+}
+
+.Vlt-icon-close.right-sec__close-icn {
+  cursor: pointer;
+  display: block;
+  font-size: 2.8rem;
+  color: #881fff;
+}
+
+.Vlt-icon-close:before {
+  content: "\e90e";
 }
 
 .list.l3-nav__menu-options--list {
@@ -1194,6 +1223,112 @@ a.l3-nav__submenu:hover {
   text-decoration: none;
 }
 
+.l3-nav__mobile {
+  margin-top: 6rem;
+  background: #fbfbfb;
+  background: -webkit-gradient(linear,left bottom,left top,color-stop(85%,#fbfbfb),to(#efefef));
+  background: linear-gradient(0deg,#fbfbfb 85%,#efefef);
+}
+
+.l3-nav__mobile--menu-head span.separator {
+  margin: 0 8px;
+}
+
+span.Vlt-icon-chevron.right-sec__dropdown-icn {
+  cursor: pointer;
+  display: block;
+  font-size: 2.8rem;
+  color: #881fff;
+  font-family: 'VltIcons';
+}
+
+span.Vlt-icon-chevron.right-sec__dropdown-icn:before {
+  content: "\e90d";
+}
+
+.l3-nav__mobile--menu-head {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb 0 0 no-repeat padding-box;
+  height: 5rem;
+  padding: 0 1.5rem;
+  font-size: 1.4rem;
+  font-weight: 500;
+  font-family: Spezia;
+}
+
+.l3-nav__mobile--menu-head.l3-nav__mobile--closed {
+  height: 5.1rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.l3-nav__mobile--menu-head.l3-nav__mobile--closed.not-active {
+  display: none;
+}
+
+.l3-nav__mobile--menu-body .menu-sub-list ul {
+  list-style-type: none;
+  padding: 0 1rem;
+  margin-top: 0;
+}
+
+.l3-nav__mobile--menu-body .menu-sub-list ul li {
+  cursor: pointer;
+  font-size: 1.4rem;
+  margin-bottom: 1.25rem;
+}
+
+.l3-nav__mobile--menu-body .menu-sub-list ul li a {
+  padding: 0.5rem;
+  color: #717171;
+}
+
+.l3-nav__mobile--menu-body {
+  right: 0;
+  z-index: 4;
+  display: none;
+  height: auto;
+  font-size: 1.4rem;
+  font-weight: 400;
+  font-family: Spezia;
+  left: 0;
+  background: #fbfbfb 0 0 no-repeat padding-box;
+  border-bottom: 1px solid #ddd;
+  position: fixed;
+  color: #717171;
+  padding: 1rem 1.5rem 0;
+  max-height: 50rem;
+  overflow-y: auto;
+  -ms-scroll-chaining: none;
+  overscroll-behavior: contain;
+}
+.l3-nav__mobile--menu-body .title-item {
+  display: block;
+  margin-bottom: 1.5rem;
+  margin-top: 1.5rem;
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: #000;
+}
+
+.l3-nav__mobile--menu-body.active {
+  display: block;
+  -webkit-animation: fadein .75s forwards;
+  animation: fadein .75s forwards;
+}
+
+.l3-nav__mobile--menu-head a:hover {
+  color: #000;
+  text-decoration: none;
+}
+
 @media (min-width: 576px) {
   .container.section-container, .container.sublist-container {
     max-width: 540px;
@@ -1212,4 +1347,14 @@ a.l3-nav__submenu:hover {
   }
 }
 
+@media only screen and (max-width: 1023px) {
+  header .l3-nav__desktop {
+    display:none;
+  }
+}
 
+@media only screen and (min-width: 1024px) {
+ header .l3-nav__mobile {
+    display:none;
+  }
+}

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -29,6 +29,10 @@ header {
   z-index: 1000;
 }
 
+header.header-wrapper.collapsed {
+  height: 6.3rem;
+}
+
 /* Div element to cover the page content  */
 header .header.block {
   background-color: var(--nav-background-color);
@@ -456,22 +460,39 @@ header #nav .sub-menu-section-active > ul.sub-menu-index {
   padding-left: 0;
 }
 
-  /* Style the last sections menu element as the contact us button */
-  header #nav[aria-expanded="true"] .nav-sections > ul > div:last-child > li {
-    border-radius: 1rem;
-    width: fit-content;
-    color: var(--mobile-nav-extended-contact-button-color);
-    background-color: var(--mobile-nav-extended-contact-button-background-color);
-    margin-right: 0;
-    height: 7.0rem;
-    line-height: 7.0rem;
-    font-size: 1.8rem;
-    padding-left: 2rem;
-    padding-right: 2rem;
-    text-decoration: none;
+  /* Primary CTA button styling in the header */
+header #nav .nav-sections > ul > div > li > strong > a {
+  border-radius: 1rem;
+  color: var(--nav-contact-button-color);
+  background-color: var(--nav-contact-button-background-color);
+  height: 4.5rem;
+  line-height: 4.5rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  margin: 0;
+  font-size: 1.5rem;
+  display: inline-block;
+}
 
-  }
+header #nav .nav-sections > ul > div > li > strong > a:hover {
+text-decoration: none;
+}
 
+header #nav .nav-sections > ul > div > li > em > a {
+  display: inline-block;
+  font-size: 1.5rem;
+  height: 4.5rem;
+  line-height: 4.5rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  border: 1px solid black;
+  border-radius: 1rem;
+  margin-left: auto;
+}
+
+header #nav .nav-sections > ul > div > li > em > a:hover {
+  text-decoration: none;
+}
 /* When in a subsection yeet all the main menu elements off to the side as an animation */
 
 /* Think about moving the aria-expanded attribute up the dom so that it can be referenced to control the logo state */
@@ -579,7 +600,6 @@ header .sub-menu-label-active {
       display: flex;
       padding-left: 0;
       margin: 0;
-      cursor: pointer;
       width: 100%;
     }
 
@@ -610,26 +630,37 @@ header .sub-menu-label-active {
     /* Disable animations for section drop down menus in desktop mode */
     header #nav .nav-sections ul div.nav-item-wrapper > li {
       transition-delay: 0s;
+      cursor: pointer;
     }
 
     /* Make the last item of the sections nav the 'Contact us' button in black and aligned to the right */
-    header #nav .nav-sections > ul > div:last-child {
-      margin: auto 0 auto auto;
-      height:4.5rem;
-    }
+    /*header #nav .nav-sections > ul > div:last-child {*/
+    /*  margin: auto 0 auto auto;*/
+    /*  height:4.5rem;*/
+    /*}*/
 
-    header #nav .nav-sections > ul > div:last-child > li {
-      border-radius: 1rem;
-      color: var(--nav-contact-button-color);
-      background-color: var(--nav-contact-button-background-color);
-      height: 4.5rem;
-      line-height: 4.5rem;
-      font-size: 1.5rem;
-      padding-left: 2rem;
-      padding-right: 2rem;
-      margin: 0;
-    }
+    /*header #nav .nav-sections > ul > div:last-child > li {*/
+    /*  border-radius: 1rem;*/
+    /*  color: var(--nav-contact-button-color);*/
+    /*  background-color: var(--nav-contact-button-background-color);*/
+    /*  height: 4.5rem;*/
+    /*  line-height: 4.5rem;*/
+    /*  font-size: 1.5rem;*/
+    /*  margin: 0;*/
+    /*}*/
 
+  .nav-item-wrapper.cta li {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .nav-item-wrapper.cta {
+    margin-left: 1rem;
+  }
+
+  .nav-item-wrapper.cta.first {
+    margin-left: auto;
+  }
     /* Colorize the transparent bottom border under the section menu items on mouse over */
     header #nav .nav-sections > ul > div.nav-item-wrapper > li:hover {
       text-decoration: underline;
@@ -923,7 +954,7 @@ header .nav-breadcrumb-wrapper {
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  height: 5.2rem;
+  height: 6.3rem;
   padding: 0 34px 5px;
   position: relative;
   background: #fbfbfb 0 0 no-repeat padding-box;
@@ -1130,6 +1161,10 @@ a.title-option__l3nav:hover {
   color: #717171;
   font-size: 1.25rem;
   font-weight: 400;
+}
+
+.l3-nav__menu-options--list li:last-of-type {
+  padding-bottom: 2rem;
 }
 
 a.l3-nav__submenu:hover {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -968,11 +968,7 @@ header .sub-menu-label-active {
       display: -webkit-box;
       display: flex;
       box-sizing: border-box;
-      -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
       justify-content: space-between;
-      -webkit-box-align: center;
-      -ms-flex-align: center;
       align-items: center;
       height: 6.3rem;
       position: relative;
@@ -980,6 +976,7 @@ header .sub-menu-label-active {
       font-weight: 500;
       font-family: var(--body-font-family);
       padding: 10px 34px 5px;
+      margin-top: 1rem;
       background: #fbfbfb;
       background: -webkit-gradient(linear,left bottom,left top,color-stop(85%,#fbfbfb),to(#efefef));
       background: linear-gradient(0deg,#fbfbfb 85%,#efefef);

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -563,6 +563,7 @@ header .sub-menu-label-active {
     header .nav-logo-big {
       top:3.9rem;
       height: 3.9rem;
+      left: 0;
     }
 
     header .nav-logo-small {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -59,6 +59,11 @@ header .nav-wrapper {
   margin: 0 auto;
 }
 
+/* Style to toggle the display of the main nav element */
+header.collapsed .nav-wrapper {
+  display: none;
+}
+
 /* Styling for the div container that holds the two versions of the logo image */
 header .nav-logo {
   position: absolute;
@@ -987,6 +992,11 @@ header .sub-menu-label-active {
       background: -webkit-gradient(linear,left bottom,left top,color-stop(85%,#fbfbfb),to(#efefef));
       background: linear-gradient(0deg,#fbfbfb 85%,#efefef);
       border-bottom: 1px solid #ddd;
+    }
+
+    /* Drop the top margin on the desktop breadcrumb when the main nav is collapsed  */
+    header.collapsed .l3-nav-desktop {
+      margin-top: 0;
     }
 
     /* Layout and styling for the div flex box for the two sections of the desktop breadcrumb */

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -27,6 +27,7 @@ header {
   width: 100%;
   background-color: white;
   z-index: 1000;
+  height: calc(var(--mobile-nav-height));
 }
 
 header.header-wrapper.collapsed {
@@ -527,6 +528,11 @@ header .sub-menu-label-active {
 /***** Desktop behavior with full nav menu displayed *****/
 @media (min-width: 992px) {
   /***** Desktop nav layout *****/
+
+    header {
+      height: calc(var(--nav-height) + var(--bread-crumb-height));
+    }
+
     header #nav {
       display: flex;
       flex-flow: column-reverse nowrap;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -27,7 +27,7 @@ header {
   width: 100%;
   background-color: white;
   z-index: 1000;
-  height: calc(var(--mobile-nav-height));
+  height:var(--mobile-nav-height);
 }
 
 header.header-wrapper.collapsed {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -493,6 +493,7 @@ header #nav .nav-sections > ul > div > li > em > a {
 header #nav .nav-sections > ul > div > li > em > a:hover {
   text-decoration: none;
 }
+
 /* When in a subsection yeet all the main menu elements off to the side as an animation */
 
 /* Think about moving the aria-expanded attribute up the dom so that it can be referenced to control the logo state */
@@ -634,20 +635,32 @@ header .sub-menu-label-active {
     }
 
     /* Make the last item of the sections nav the 'Contact us' button in black and aligned to the right */
-    /*header #nav .nav-sections > ul > div:last-child {*/
-    /*  margin: auto 0 auto auto;*/
-    /*  height:4.5rem;*/
-    /*}*/
 
-    /*header #nav .nav-sections > ul > div:last-child > li {*/
-    /*  border-radius: 1rem;*/
-    /*  color: var(--nav-contact-button-color);*/
-    /*  background-color: var(--nav-contact-button-background-color);*/
-    /*  height: 4.5rem;*/
-    /*  line-height: 4.5rem;*/
-    /*  font-size: 1.5rem;*/
-    /*  margin: 0;*/
-    /*}*/
+    /* header #nav .nav-sections > ul > div:last-child { */
+
+    /*  margin: auto 0 auto auto; */
+
+    /*  height:4.5rem; */
+
+    /* } */
+
+    /* header #nav .nav-sections > ul > div:last-child > li { */
+
+    /*  border-radius: 1rem; */
+
+    /*  color: var(--nav-contact-button-color); */
+
+    /*  background-color: var(--nav-contact-button-background-color); */
+
+    /*  height: 4.5rem; */
+
+    /*  line-height: 4.5rem; */
+
+    /*  font-size: 1.5rem; */
+
+    /*  margin: 0; */
+
+    /* } */
 
   .nav-item-wrapper.cta li {
     margin-left: 0;
@@ -661,6 +674,7 @@ header .sub-menu-label-active {
   .nav-item-wrapper.cta.first {
     margin-left: auto;
   }
+
     /* Colorize the transparent bottom border under the section menu items on mouse over */
     header #nav .nav-sections > ul > div.nav-item-wrapper > li:hover {
       text-decoration: underline;
@@ -943,9 +957,9 @@ header .sub-menu-label-active {
 }
 
 
-header .nav-breadcrumb-wrapper {
+header .l3-nav__desktop {
   display: -webkit-box;
-  display: -ms-flexbox;
+  display: flexbox;
   display: flex;
   box-sizing: border-box;
   -webkit-box-pack: justify;
@@ -957,7 +971,6 @@ header .nav-breadcrumb-wrapper {
   height: 6.3rem;
   padding: 0 34px 5px;
   position: relative;
-  background: #fbfbfb 0 0 no-repeat padding-box;
   font-size: 1.3rem;
   font-weight: 500;
   font-family: Spezia;
@@ -987,14 +1000,14 @@ header .nav-breadcrumb-wrapper {
 
 .left-sec {
   display: -webkit-box;
-  display: -ms-flexbox;
+  display: flexbox;
   display: flex;
   align-items: center;
 }
 
 .right-sec {
   display: -webkit-box;
-  display: -ms-flexbox;
+  display: flexbox;
   display: flex;
   align-items: center;
 }
@@ -1006,7 +1019,7 @@ header .nav-breadcrumb-wrapper {
 
 .l3-nav__menu-title {
   display: -webkit-box;
-  display: -ms-flexbox;
+  display: flexbox;
   display: flex;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1029,7 +1042,7 @@ span.separator {
 
 a.title-option__l3nav {
   display: -webkit-box;
-  display: -ms-flexbox;
+  display: flexbox;
   display: flex;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1064,7 +1077,7 @@ span.Vlt-icon-chevron.arrow-icn {
   display: inline-block;
   font-size: 2rem;
   position: relative;
-  -webkit-transform: rotate(0deg);
+  transform: rotate(0deg);
   transform: rotate(0deg);
   color: #881fff;
 }
@@ -1111,11 +1124,11 @@ a.title-option__l3nav:hover {
 .menu-option-sublist.l3-nav__menu-options.active {
   opacity:100;
   display: -webkit-box;
-  display: -ms-flexbox;
+  display: flexbox;
   display: flex;
   visibility: visible;
   z-index: 4;
-  -webkit-animation: fadein .75s forwards;
+  animation: fadein .75s forwards;
   animation: fadein .75s forwards;
 }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -990,6 +990,12 @@ span.title-option {
   color: #000;
 }
 
+span.separator {
+  color: #881fff;
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
 a.title-option__l3nav {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -1041,6 +1047,20 @@ a.title-option__l3nav.active:hover {
   color: #000;
 }
 
+a.title-option__l3nav:hover {
+  text-decoration: none;
+}
+
+.l3-nav__menu-options--list ul li a.bold {
+  font-weight: 600;
+  color: #000;
+}
+
+.bold {
+  font-weight: 600;
+  color: #000;
+}
+
 .menu-option-sublist.l3-nav__menu-options {
   opacity: 0;
   visibility: hidden;
@@ -1080,6 +1100,12 @@ a.title-option__l3nav.active:hover {
 
 .list.l3-nav__menu-options--list.first {
   padding-left: 25px;
+  box-sizing: border-box;
+}
+
+.l3-nav__menu-title:last-child .title-option__l3nav {
+  font-weight: 600;
+  color: #000;
 }
 
 .list.l3-nav__menu-options--list {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1,21 +1,21 @@
 /* stylelint-disable no-descending-specificity */
 
 :root {
-  --nav-color: #000;
+  --nav-color: var(--text-color);
   --nav-tools-color: #5f6169;
-  --nav-logo-color: #000;
+  --nav-logo-color: var(--text-color);
   --nav-background-color: #FFF;
-  --nav-decoration-color: #000;
+  --nav-decoration-color: var(--text-color);
   --nav-section-tab-color: #6f54a3;
   --nav-extended-color: #FFF;
-  --mobile-nav-extended-background: #000;
+  --mobile-nav-extended-background: var(--text-color);
   --mobile-nav-extended-logo-color: #FFF;
   --mobile-nav-extended-color: #FFF;
   --mobile-nav-extended-decoration-color: #FFF;
-  --mobile-nav-extended-contact-button-color: #000;
+  --mobile-nav-extended-contact-button-color: var(--text-color);
   --mobile-nav-extended-contact-button-background-color: #FFF;
    --nav-contact-button-color: #FFF;
-   --nav-contact-button-background-color: #000;
+   --nav-contact-button-background-color: var(--text-color);
 }
 
 /***** Global header / nav menu structure and styling *****/
@@ -61,7 +61,7 @@ header .nav-wrapper {
 /* Styling for the div container that holds the two versions of the logo image */
 header .nav-logo {
   position: absolute;
-  color: #000;
+  color: var(--text-color);
   left: 2rem;
   top: 2.2rem;
   width: 10.2rem;
@@ -467,8 +467,6 @@ header #nav .sub-menu-section-active > ul.sub-menu-index {
   /* Primary CTA button styling in the header */
 header #nav .nav-sections > ul > div > li > strong > a {
   border-radius: 1rem;
-  color: var(--nav-contact-button-color);
-  background-color: var(--nav-contact-button-background-color);
   height: 4.5rem;
   line-height: 4.5rem;
   padding-left: 2rem;
@@ -476,7 +474,7 @@ header #nav .nav-sections > ul > div > li > strong > a {
   margin: 0;
   font-size: 1.5rem;
   display: inline-block;
-  color: #000;
+  color: var(--text-color);
   background-color: #FFF;
 }
 
@@ -494,7 +492,7 @@ header #nav .nav-sections > ul > div > li > em > a {
   border: 1px solid black;
   border-radius: 1rem;
   margin-left: auto;
-  color: #000;
+  color: var(--text-color);
   background-color: #FFF;
 }
 
@@ -707,14 +705,13 @@ header .sub-menu-label-active {
       top: 0;
       content: var(--vlt-up-right-arrow-icon);
       bottom: 0;
-      font-family: VltIcons;
+      font-family: var(--icon-font-family);
       font-size: .8rem;
       position: absolute;
     }
 
     /* Position and style the search icon displayed adjacent to the tools menu */
     header #nav div.nav-search {
-      -ms-flex-item-align: center;
       align-self: center;
       display: flex;
       font-size: 1.5rem;
@@ -768,13 +765,13 @@ header .sub-menu-label-active {
       left: 1265px;
       top: -1rem;
       content: var(--vlt-close-icon);
-      font-family: VltIcons;
+      font-family: var(--icon-font-family);
       color: black;
     }
 
     header #nav span.close-icon::before {
       content: var(--vlt-close-icon);
-      font-family: VltIcons;
+      font-family: var(--icon-font-family);
       font-size: 40px;
     }
 
@@ -924,10 +921,10 @@ header .sub-menu-label-active {
         background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='14'%3E%3Cpath d='M12.56 1.21a1 1 0 00-1.46 1.38L14.31 6H0v2h14.31l-3.21 3.41a1 1 0 001.46 1.37L18 7z'/%3E%3C/svg%3E");
       }
 
-    /* Add the icons to the index elements as peudo befores */
+    /* Add the icons to the index elements as pseudo before */
     header #nav ul.sub-menu-index #communications-apis::before {
       content: var(--vlt-cloud-inverse-icon);
-      font-family: VltIcons;
+      font-family: var(--icon-font-family);
       margin: 1.1rem;
       left: -2.9rem;
       position: absolute;
@@ -936,7 +933,7 @@ header .sub-menu-label-active {
 
     header #nav ul.sub-menu-index #unified-communications::before {
       content: var(--vlt-phone-2-icon);
-      font-family: VltIcons;
+      font-family: var(--icon-font-family);
       margin: 1.1rem;
       left: -2.9rem;
       position: absolute;
@@ -945,7 +942,7 @@ header .sub-menu-label-active {
 
     header #nav ul.sub-menu-index #contact-centers::before {
       content: var(--vlt-head-phone-icon);
-      font-family: VltIcons;
+      font-family: var(--icon-font-family);
       margin: 1.1rem;
       left: -2.9rem;
       position: absolute;
@@ -954,7 +951,7 @@ header .sub-menu-label-active {
 
     header #nav ul.sub-menu-index #conversational-commerce::before {
       content: var(--vlt-mobile-text-bubble-icon);
-      font-family: VltIcons;
+      font-family: var(--icon-font-family);
       margin: 1.1rem;
       left: -2.9rem;
       position: absolute;
@@ -962,372 +959,390 @@ header .sub-menu-label-active {
     }
 }
 
+/***** Desktop breadcrumb element  *****/
 
-header .l3-nav__desktop {
-  display: -webkit-box;
-  display: flex;
-  box-sizing: border-box;
-  -webkit-box-pack: justify;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 6.3rem;
-  padding: 0 34px 5px;
-  position: relative;
-  font-size: 1.3rem;
-  font-weight: 500;
-  font-family: Spezia;
-  padding-top: 10px;
-  background: #fbfbfb;
-  background: -webkit-gradient(linear,left bottom,left top,color-stop(85%,#fbfbfb),to(#efefef));
-  background: linear-gradient(0deg,#fbfbfb 85%,#efefef);
-  border-bottom: 1px solid #ddd;
-}
+  /***** Desktop breadcrumb structure layout and styling *****/
 
-.container.section-container {
-  display: flex;
-  line-height: normal;
-  box-sizing: border-box;
-  -webkit-box-pack: justify;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 100%;
-  padding-right: 20px;
-  padding-left: 20px;
-  margin-right: auto;
-  margin-left: auto;
-}
+    /* Layout and styling for the desktop breadcrumb header element parent element */
+    header .l3-nav-desktop {
+      display: -webkit-box;
+      display: flex;
+      box-sizing: border-box;
+      -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+      justify-content: space-between;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      height: 6.3rem;
+      position: relative;
+      font-size: 1.3rem;
+      font-weight: 500;
+      font-family: var(--body-font-family);
+      padding: 10px 34px 5px;
+      background: #fbfbfb;
+      background: -webkit-gradient(linear,left bottom,left top,color-stop(85%,#fbfbfb),to(#efefef));
+      background: linear-gradient(0deg,#fbfbfb 85%,#efefef);
+      border-bottom: 1px solid #ddd;
+    }
 
-.left-sec {
-  display: -webkit-box;
-  display: flexbox;
-  display: flex;
-  align-items: center;
-}
+    /* Layout and styling for the div flex box for the two sections of the desktop breadcrumb */
+    header .l3-nav-desktop .container.section-container {
+      display: flex;
+      line-height: normal;
+      box-sizing: border-box;
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+      padding-right: 20px;
+      padding-left: 20px;
+      margin-right: auto;
+      margin-left: auto;
+    }
 
-.right-sec {
-  display: -webkit-box;
-  display: flexbox;
-  display: flex;
-  align-items: center;
-}
+    /* Layout for the left column of the desktop breadcrumb */
+    header .l3-nav-desktop .left-sec {
+      display: -webkit-box;
+      display: flex;
+      align-items: center;
+    }
 
-.right-sec__menu-option {
-  margin-right: 4rem;
-  cursor: pointer;
-}
+    /* Layout for the left column of the desktop breadcrumb */
+    header .l3-nav-desktop .right-sec {
+      display: -webkit-box;
+      display: flex;
+      align-items: center;
+    }
 
-.l3-nav__menu-title {
-  display: -webkit-box;
-  display: flexbox;
-  display: flex;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-right: 1.5rem;
-  min-width: 8rem;
-  cursor: pointer;
-}
+    /* Layout and pointer behavior for the links in the desktop right breadcrumb */
+    header .l3-nav-desktop .right-sec-menu-option {
+      margin-right: 4rem;
+      cursor: pointer;
+    }
 
-span.title-option {
-  margin-right: 1.5rem;
-  color: #000;
-}
+  /***** Desktop breadcrumb header bar styling *****/
 
-span.separator {
-  color: #881fff;
-  font-size: 1.3rem;
-  font-weight: 600;
-}
+    /* Styling for the breadcrumb section title elements parent container */
+    header .l3-nav-desktop .l3-nav-menu-title {
+      display: -webkit-box;
+      display: flex;
+      align-items: center;
+      margin-right: 1.5rem;
+      min-width: 8rem;
+      cursor: pointer;
+    }
 
-a.title-option__l3nav {
-  display: -webkit-box;
-  display: flexbox;
-  display: flex;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #717171;
-}
 
-a.title-option__l3nav.active {
-  color: #000;
-}
+    /* Styling for the breadcrumb section title elements */
+    header .l3-nav-desktop span.title-option {
+      margin-right: 1.5rem;
+      color: var(--text-color);
+    }
 
-span.nav-icon.Vlt-icon-phone {
-  color: #000;
-  padding-right: 10px;
-  font-size: 1.5rem;
-  font-family: VltIcons!important;
-  font-style: normal;
-  font-variant: normal;
-  font-weight: 400;
-  line-height: inherit;
-  speak: none;
-  text-transform: none;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
+    /* Styling for the breadcrumb section title separator '/' elements */
+    header .l3-nav-desktop span.separator {
+      color: var(--accent-color);
+      font-size: 1.3rem;
+      font-weight: 600;
+    }
 
-span.nav-icon.Vlt-icon-phone::before {
-  content: "\e939";
-}
+    /* Styling for the title link in the breadcrumb */
+    header .l3-nav-desktop a.title-option-l3nav {
+      display: flex;
+      align-items: center;
+      color: #717171;
+    }
 
-span.Vlt-icon-chevron.arrow-icn {
-  display: inline-block;
-  font-size: 2rem;
-  position: relative;
-  transform: rotate(0deg);
-  transform: rotate(0deg);
-  color: #881fff;
-}
+    /* Styling for the prepended icon decoration span in the desktop breadcrumb title */
+    header .l3-nav-desktop span.nav-icon.vlt-icon-phone {
+      color: var(--text-color);
+      padding-right: 10px;
+      font-size: 1.5rem;
+      font-family: var(--icon-font-family);
+      font-style: normal;
+      font-variant: normal;
+      font-weight: 400;
+      line-height: inherit;
+      speak: none;
+      text-transform: none;
+    }
 
-span.Vlt-icon-chevron.arrow-icn::before {
-  content: "\e90d";
-}
+    /* Icon for the prepended decoration span in the desktop breadcrumb title */
+    header .l3-nav-desktop span.nav-icon.vlt-icon-phone::before {
+      content: var(--vlt-phone-2-icon);
+    }
 
-a.title-option__l3nav.active:hover {
-  text-decoration: none;
-  color: #000;
-}
+    /* Styling for the appended icon decoration in the desktop breadcrumb title */
+    header .l3-nav-desktop span.vlt-icon-chevron.arrow-icn {
+      display: inline-block;
+      font-size: 2rem;
+      position: relative;
+      transform: rotate(0deg);
+      color: var(--accent-color);
+    }
 
-a.title-option__l3nav:hover {
-  text-decoration: none;
-}
+    /* Icon for the appended decoration span in the desktop breadcrumb title */
+    header .l3-nav-desktop span.vlt-icon-chevron.arrow-icn::before {
+      content: var(--vlt-down-chevron-icon);
+    }
 
-.l3-nav__menu-options--list ul li a.bold {
-  font-weight: 600;
-  color: #000;
-}
+    /* Don't underline desktop breadcrumb title links on hover */
+    header .l3-nav-desktop a.title-option-l3nav:hover {
+      text-decoration: none;
+    }
 
-.bold {
-  font-weight: 600;
-  color: #000;
-}
+    /* Make the active (page user is on) link in the title bold and black */
+    header .l3-nav-desktop .l3-nav-menu-title .title-option-l3nav.bold {
+      font-weight: 600;
+      color: var(--text-color);
+    }
 
-.menu-option-sublist.l3-nav__menu-options {
-  opacity: 0;
-  visibility: hidden;
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 5rem;
-  padding: 0 34px 17px;
-  max-height: 40rem;
-  overflow-y: auto;
-  -ms-scroll-chaining: none;
-  overscroll-behavior: contain;
-  background: #fbfbfb 0 0 no-repeat padding-box;
-  border-bottom: 1px solid #ddd;
-}
+    /*  Styling for the right section of the desktop breadcrumb header bar */
+    header .l3-nav-desktop .right-sec-menu-option a {
+      color: var(--text-color);
+    }
 
-.menu-option-sublist.l3-nav__menu-options.active {
-  opacity:100;
-  display: -webkit-box;
-  display: flexbox;
-  display: flex;
-  visibility: visible;
-  z-index: 4;
-  animation: fadein .75s forwards;
-  animation: fadein .75s forwards;
-}
+    /*  Disable underline for the right section of the desktop breadcrumb header bar */
+    header .l3-nav-desktop .right-sec-menu-option a:hover {
+      text-decoration: none;
+    }
 
-.container.sublist-container {
-  display: flex;
-  margin-left: auto;
-  margin-right: auto;
-  width: 100%;
-  padding-right: 20px;
-  padding-left: 20px;
-  box-sizing: border-box;
-}
+  /***** Desktop breadcrumb body styling *****/
 
-.list.l3-nav__menu-options--list.first {
-  padding-left: 25px;
-  box-sizing: border-box;
-}
+    /* Layout and position for top level parent of the breadcrumb container before activated */
+    header .l3-nav-desktop .menu-option-sublist.l3-nav-menu-options {
+      opacity: 0;
+      visibility: hidden;
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 5rem;
+      padding: 0 34px 17px;
+      max-height: 40rem;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+      background: #fbfbfb 0 0 no-repeat padding-box;
+      border-bottom: 1px solid #ddd;
+    }
 
-.l3-nav__mobile--closed.not-active, .l3-nav__mobile--open.not-active {
-  display: none;
-}
+    /* Style to apply to the breadcrumb container to render it visible */
+    header .l3-nav-desktop .menu-option-sublist.l3-nav-menu-options.active {
+      opacity:100;
+      display: flex;
+      visibility: visible;
+      z-index: 4;
+      animation: fadein .75s forwards;
+    }
 
-.l3-nav__menu-title .title-option__l3nav.boldbreadCrumbTitle {
-  font-weight: 600;
-  color: #000;
-}
+    /* Sub container for the link data in the breadcrumb */
+    header .l3-nav-desktop .container.sublist-container {
+      display: flex;
+      margin-left: auto;
+      margin-right: auto;
+      width: 100%;
+      padding-right: 20px;
+      padding-left: 20px;
+      box-sizing: border-box;
+    }
 
-.l3-nav__mobile--menu-body .menu-sub-list ul li a.bold {
-  font-weight: 500;
-  color: #000;
-}
+    /* Styling for the breadcrumb body columns */
+    header .l3-nav-desktop .list.l3-nav-menu-options-list {
+      min-width: 8rem;
+      margin-right: 1.5rem;
+    }
 
-.l3-nav__mobile--menu-body .title-item:hover {
-  text-decoration: none;
-}
+    /* Styling for the first link column in the expanded breadcrumb */
+    header .l3-nav-desktop .list.l3-nav-menu-options-list.first {
+      padding-left: 25px;
+      box-sizing: border-box;
+    }
 
-.Vlt-icon-close.right-sec__close-icn {
-  cursor: pointer;
-  display: block;
-  font-size: 2.8rem;
-  color: #881fff;
-}
+    /* Styling for the ul container of the desktop breadcrumb body */
+    header .l3-nav-desktop .l3-nav-menu-options-list ul {
+      list-style-type: none;
+      padding: 0;
+      margin: 0;
+    }
 
-.Vlt-icon-close:before {
-  content: "\e90e";
-}
+    /* Styling for the li container of the desktop breadcrumb body */
+    header .l3-nav-desktop .l3-nav-menu-options-list li {
+      cursor: pointer;
+      min-height: 1rem;
+      margin-bottom: 1rem;
+      line-height: normal;
+    }
 
-.list.l3-nav__menu-options--list {
-  min-width: 8rem;
-  margin-right: 1.5rem;
-}
+    /* Styling for the breadcrumb body link text */
+    header .l3-nav-desktop .l3-nav-menu-options-list ul li a{
+      color: #717171;
+      font-size: 1.25rem;
+      font-weight: 400;
+    }
 
-.l3-nav__menu-options--list ul {
-  list-style-type: none;
-  padding: 0;
-  margin: 0;
-}
+    /* Make the active (page user is on) link in the breadcrumb bold and black */
+    header .l3-nav-desktop .l3-nav-menu-options-list ul li a.bold {
+      font-weight: 600;
+      color: var(--text-color);
+    }
 
-.l3-nav__menu-options--list li {
-  cursor: pointer;
-  min-height: 1rem;
-  margin-bottom: 1rem;
-  line-height: normal;
-}
+    /* Add some padding to the last list element in the desktop breadcrumb body */
+    header .l3-nav-desktop .l3-nav-menu-options-list li:last-of-type {
+      padding-bottom: 2rem;
+    }
 
-.l3-nav__menu-options--list ul li a{
-  color: #717171;
-  font-size: 1.25rem;
-  font-weight: 400;
-}
+   /* Make black and add an accentu underline to desktop breadcrumb body links on hover */
+   header .l3-nav-desktop a.l3-nav-submenu:hover {
+    text-decoration: none;
+    color: var(--text-color);
+    border-bottom: 2px solid var(--accent-color);
+  }
 
-.l3-nav__menu-options--list li:last-of-type {
-  padding-bottom: 2rem;
-}
+/***** Mobile breadcrumb element *****/
 
-a.l3-nav__submenu:hover {
-  text-decoration: none;
-  color: #000;
-  border-bottom: 2px solid #881fff;
-}
+  /***** Mobile breadcrumb layout and structure *****/
 
-.right-sec__menu-option a {
-  color: #000;
-}
+  /* Styling and layout of parent container for mobile breadcrumb title element */
+  header .l3-nav-mobile {
+    margin-top: 6rem;
+    background: #fbfbfb;
+    background: -webkit-gradient(linear,left bottom,left top,color-stop(85%,#fbfbfb),to(#efefef));
+    background: linear-gradient(0deg,#fbfbfb 85%,#efefef);
+  }
 
-.right-sec__menu-option a:hover {
-  text-decoration: none;
-}
+  /***** Mobile breadcrumb element header styling *****/
 
-.l3-nav__mobile {
-  margin-top: 6rem;
-  background: #fbfbfb;
-  background: -webkit-gradient(linear,left bottom,left top,color-stop(85%,#fbfbfb),to(#efefef));
-  background: linear-gradient(0deg,#fbfbfb 85%,#efefef);
-}
+    /* Styling for the breadcrumb headers open button */
+    header .l3-nav-mobile .vlt-icon-chevron.right-sec-dropdown-icn {
+      cursor: pointer;
+      display: block;
+      font-size: 2.8rem;
+      color: var(--accent-color);
+      font-family: var(--icon-font-family);
+    }
 
-.l3-nav__mobile--menu-head span.separator {
-  margin: 0 8px;
-}
+    /* Content for the breadcrumb headers open button */
+    header .l3-nav-mobile .vlt-icon-chevron.right-sec-dropdown-icn::before {
+      content: var(--vlt-down-chevron-icon);
+    }
 
-span.Vlt-icon-chevron.right-sec__dropdown-icn {
-  cursor: pointer;
-  display: block;
-  font-size: 2.8rem;
-  color: #881fff;
-  font-family: 'VltIcons';
-}
+    /* Styling for the breadcrumb headers close button */
+    header .l3-nav-mobile .vlt-icon-close.right-sec-close-icn {
+      cursor: pointer;
+      display: block;
+      font-size: 2.8rem;
+      color: var(--accent-color);
+    }
 
-span.Vlt-icon-chevron.right-sec__dropdown-icn:before {
-  content: "\e90d";
-}
+    /* Content for the breadcrumb headers close button */
+    header .l3-nav-mobile .vlt-icon-close::before {
+      content: var(--vlt-close-icon);
+    }
 
-.l3-nav__mobile--menu-head {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #fbfbfb 0 0 no-repeat padding-box;
-  height: 5rem;
-  padding: 0 1.5rem;
-  font-size: 1.4rem;
-  font-weight: 500;
-  font-family: Spezia;
-}
+    /* Styling for the breadcrumbb headers title separators */
+    header .l3-nav-mobile .l3-nav-mobile-menu-head .left-sec .separator {
+      margin: 0 8px;
+      color: var(--accent-color);
+    }
 
-.l3-nav__mobile--menu-head.l3-nav__mobile--closed {
-  height: 5.1rem;
-  border-bottom: 1px solid #ddd;
-}
+    /* Styling for either of the mobile nav title containers (open and closed) */
+    header .l3-nav-mobile .l3-nav-mobile-menu-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: #fbfbfb 0 0 no-repeat padding-box;
+      height: 5rem;
+      padding: 0 1.5rem;
+      font-size: 1.4rem;
+      font-weight: 500;
+      font-family: var(--body-font-family);
+    }
 
-.l3-nav__mobile--menu-head.l3-nav__mobile--closed.not-active {
-  display: none;
-}
+    /* Don't underline the mobile breadcrumb header links on hover */
+    header .l3-nav-mobile .l3-nav-mobile-menu-head a:hover {
+      color: var(--text-color);
+      text-decoration: none;
+    }
 
-.l3-nav__mobile--menu-body .menu-sub-list ul {
-  list-style-type: none;
-  padding: 0 1rem;
-  margin-top: 0;
-}
+    /* Specific styles for the closed mobile breadcrumb title element */
+    header .l3-nav-mobile .l3-nav-mobile-menu-head.l3-nav-mobile-closed {
+      height: 5.1rem;
+      border-bottom: 1px solid #ddd;
+    }
 
-.l3-nav__mobile--menu-body .menu-sub-list ul li {
-  cursor: pointer;
-  font-size: 1.4rem;
-  margin-bottom: 1.25rem;
-}
+    /* Style to toggle the open and closed breadcrumb title variants as visible or not */
+    header .l3-nav-mobile .l3-nav-mobile-closed.not-active,
+    header .l3-nav-mobile .l3-nav-mobile-open.not-active {
+      display: none;
+    }
 
-.l3-nav__mobile--menu-body .menu-sub-list ul li a {
-  padding: 0.5rem;
-  color: #717171;
-}
+/***** Mobile breadcrumb element body styling *****/
 
-.l3-nav__mobile--menu-body {
-  right: 0;
-  z-index: 4;
-  display: none;
-  height: auto;
-  font-size: 1.4rem;
-  font-weight: 400;
-  font-family: Spezia;
-  left: 0;
-  background: #fbfbfb 0 0 no-repeat padding-box;
-  border-bottom: 1px solid #ddd;
-  position: fixed;
-  color: #717171;
-  padding: 1rem 1.5rem 0;
-  max-height: 50rem;
-  overflow-y: auto;
-  -ms-scroll-chaining: none;
-  overscroll-behavior: contain;
-}
-.l3-nav__mobile--menu-body .title-item {
-  display: block;
-  margin-bottom: 1.5rem;
-  margin-top: 1.5rem;
-  font-size: 1.4rem;
-  font-weight: 500;
-  color: #000;
-}
+    /* Layout and styling for the top level mobile breadcrumb body container */
+    header .l3-nav-mobile-menu-body {
+      right: 0;
+      z-index: 4;
+      display: none;
+      height: auto;
+      font-size: 1.4rem;
+      font-weight: 400;
+      font-family: var(--body-font-family);
+      left: 0;
+      background: #fbfbfb 0 0 no-repeat padding-box;
+      border-bottom: 1px solid #ddd;
+      position: fixed;
+      color: #717171;
+      padding: 1rem 1.5rem 0;
+      max-height: 50rem;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+    }
 
-.l3-nav__mobile--menu-body.active {
-  display: block;
-  -webkit-animation: fadein .75s forwards;
-  animation: fadein .75s forwards;
-}
+    /* Style to apply to the mobile breadcrumb body in order to render it active in the page */
+    header .l3-nav-mobile-menu-body.active {
+      display: block;
+      animation: fadein .75s forwards;
+    }
 
-.l3-nav__mobile--menu-head a:hover {
-  color: #000;
-  text-decoration: none;
-}
+    /* Don't underline mobile breadcrumb title elements on hover (they aren't actually links) */
+    header .l3-nav-mobile .l3-nav-mobile-menu-body .title-item:hover {
+      text-decoration: none;
+    }
+
+    /* Bold styling for the displayed page in the breadcrumb body */
+    header .l3-nav-mobile .l3-nav-mobile-menu-body .menu-sub-list ul li a.bold {
+      font-weight: 500;
+      color: var(--text-color);
+    }
+
+    /* Styling for the ul container in the mobile breadcrumb body */
+    header .l3-nav-mobile-menu-body .menu-sub-list ul {
+      list-style-type: none;
+      padding: 0 1rem;
+      margin-top: 0;
+    }
+
+    /* Styling for the li container in the mobile breadcrumb body */
+    header .l3-nav-mobile-menu-body .menu-sub-list ul li {
+      cursor: pointer;
+      font-size: 1.4rem;
+      margin-bottom: 1.25rem;
+    }
+
+    /* Styling for the links in the mobile breadcrumb body */
+    header .l3-nav-mobile-menu-body .menu-sub-list ul li a {
+      padding: 0.5rem;
+      color: #717171;
+    }
+
+    /* Specific styling for title items in the mobile breadcrumb body (without links) */
+    header .l3-nav-mobile-menu-body .title-item {
+      display: block;
+      margin-bottom: 1.5rem;
+      margin-top: 1.5rem;
+      font-size: 1.4rem;
+      font-weight: 500;
+      color: var(--text-color);
+    }
 
 @media (min-width: 576px) {
   .container.section-container, .container.sublist-container {
@@ -1348,13 +1363,15 @@ span.Vlt-icon-chevron.right-sec__dropdown-icn:before {
 }
 
 @media only screen and (max-width: 1023px) {
-  header .l3-nav__desktop {
+  /* Don't show the desktop breadcrumb at less than 1024 display width */
+  header .l3-nav-desktop {
     display:none;
   }
 }
 
 @media only screen and (min-width: 1024px) {
- header .l3-nav__mobile {
+ /*  Don't show the mobile breadcrumb at greater than 1024 display width */
+ header .l3-nav-mobile {
     display:none;
   }
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -52,6 +52,7 @@ header .nav-wrapper {
   position: relative;
   max-width: 132rem;
   margin: 0 auto;
+  height: var(--nav-height);
 }
 
 /* Styling for the div container that holds the two versions of the logo image */
@@ -915,6 +916,7 @@ header .nav-breadcrumb-wrapper {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   -webkit-box-pack: justify;
   -ms-flex-pack: justify;
   justify-content: space-between;
@@ -937,6 +939,7 @@ header .nav-breadcrumb-wrapper {
 
 .container.section-container {
   display: flex;
+  line-height: normal;
   box-sizing: border-box;
   -webkit-box-pack: justify;
   -ms-flex-pack: justify;
@@ -1033,7 +1036,7 @@ span.Vlt-icon-chevron.arrow-icn::before {
   content: "\e90d";
 }
 
-a.title-option {
+a.title-option__l3nav.active:hover {
   text-decoration: none;
   color: #000;
 }
@@ -1072,6 +1075,7 @@ a.title-option {
   width: 100%;
   padding-right: 20px;
   padding-left: 20px;
+  box-sizing: border-box;
 }
 
 .list.l3-nav__menu-options--list.first {
@@ -1093,12 +1097,27 @@ a.title-option {
   cursor: pointer;
   min-height: 1rem;
   margin-bottom: 1rem;
+  line-height: normal;
 }
 
 .l3-nav__menu-options--list ul li a{
   color: #717171;
   font-size: 1.25rem;
   font-weight: 400;
+}
+
+a.l3-nav__submenu:hover {
+  text-decoration: none;
+  color: #000;
+  border-bottom: 2px solid #881fff;
+}
+
+.right-sec__menu-option a {
+  color: #000;
+}
+
+.right-sec__menu-option a:hover {
+  text-decoration: none;
 }
 
 @media (min-width: 576px) {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,6 +1,6 @@
 import { decorateIcons, getMetadata, toClassName } from '../../scripts/lib-franklin.js';
 import {
-  a, div, li, span, ul,
+  a, div, hr, li, span, ul,
 } from '../../scripts/scripts.js';
 
 /* ------------------------------ Global Variables ----------------------------------- */
@@ -24,6 +24,17 @@ function scrollFunction() {
   const scrollDistance = 160;
   const newScrollY = window.scrollY;
   const scrolledDown = (oldScrollY - newScrollY < 0);
+  if (window.location.pathname.search('unified-communications/')) {
+    if ((scrolledDown && document.body.scrollTop > scrollDistance)
+      || (scrolledDown && document.documentElement.scrollTop > scrollDistance)) {
+      document.querySelector('.nav-wrapper').style.display = 'none';
+      document.querySelector('.header-wrapper').classList.add('collapsed');
+    } else {
+      document.querySelector('.nav-wrapper').style.display = '';
+      document.querySelector('.header-wrapper').classList.remove('collapsed');
+    }
+  }
+
   if ((scrolledDown && document.body.scrollTop > scrollDistance)
       || (scrolledDown && document.documentElement.scrollTop > scrollDistance)) {
     document.getElementById('nav').querySelector('.nav-tools').style.display = 'none';
@@ -113,10 +124,9 @@ function buildHierarchy(flat) {
       structuredLinks.push(item);
       // Add a children array property to the parent object
       structuredLinks[structuredLinks.length - 1].children = [];
-    }
-    // Otherwise if the link has a listed parent find it in the array
-    // and append it to the child array element of that parent
-    else {
+    } else {
+      // Otherwise if the link has a listed parent find it in the array
+      // and append it to the child array element of that parent
       const index = structuredLinks.indexOf(structuredLinks.find((o) => o.url === item.parent));
       structuredLinks[index].children.push(item);
     }
@@ -369,19 +379,20 @@ function decorateSubSections(navSection, sectionIndex) {
  * @param {HTMLElement} navSections The nodes of the section nav menu bar
  */
 function decorateSections(navSections) {
-  const sectionDivider = document.createElement('hr');
-  sectionDivider.classList.add('nav-section-divider');
+  const sectionDivider = hr({ class: 'nav-section-divider' });
   navSections.after(sectionDivider);
   navSections.querySelectorAll(':scope > ul > li').forEach((navSection) => {
     const sectionIndex = navSection.querySelector(':scope > ul');
     navSection.remove();
-    const navItemWrapper = document.createElement('div');
-    navItemWrapper.classList.add('nav-item-wrapper');
+    const navItemWrapper = div({ class: 'nav-item-wrapper' });
     navSection.id = toClassName(navSection.childNodes[0].nodeValue);
+    if (navSection.querySelectorAll('em, strong').length > 0) {
+      navItemWrapper.classList.add('cta');
+    }
     navItemWrapper.appendChild(navSection);
     navSections.querySelector('ul').appendChild(navItemWrapper);
     if (sectionIndex) {
-      const subMenuLabel = document.createElement('span');
+      const subMenuLabel = span();
       const labeltext = toClassName(navSection.childNodes[0].nodeValue);
       subMenuLabel.id = `${labeltext}-label`;
       subMenuLabel.classList.add('sub-menu-label');
@@ -421,7 +432,7 @@ function decorateSections(navSections) {
         navSection.setAttribute('aria-expanded', expanded ? 'false' : 'true');
         navSection.parentElement.setAttribute('aria-expanded', expanded ? 'false' : 'true');
       } else {
-        // For Mobile need to set the right subsection to active so it display
+        // For Mobile need to set the right subsection to active so it displayed
         document.getElementById(`sub-menu-${event.target.id}`).classList.toggle('sub-menu-section-active');
 
         // Turn on the Back to Main menu button
@@ -441,6 +452,7 @@ function decorateSections(navSections) {
       }
     });
   });
+  navSections.querySelector('.cta').classList.add('first');
 }
 
 /**
@@ -499,7 +511,7 @@ function parseBreadCrumbJSON(json) {
   const subNavs = JSON.parse(json);
 
   const breadCrumbTitles = [];
-  const breadCrumbMetaTags = ['sectiontitle', 'subsectiontitle', 'breadcrumbtitle'];
+  const breadCrumbMetaTags = ['nav-section', 'nav-subsection', 'nav-breadcrumb'];
 
   breadCrumbMetaTags.forEach((tag) => {
     const title = getMetadata(tag);
@@ -541,7 +553,7 @@ function populateBreadCrumb(data, pathArray) {
     } else {
       const separator = span({ class: 'separator' });
       separator.innerHTML = '/';
-      breadCrumb.querySelector('.left-sec :first-child').appendChild(separator);
+      breadCrumb.querySelector('.left-sec .l3-nav__menu-title:last-child').appendChild(separator);
       breadCrumbTitleElem.innerHTML = `<span class="title-option">
                                 <a class="title-option__l3nav" data-static-label="${title}">
                                     <span>${title}</span>
@@ -565,7 +577,7 @@ function populateBreadCrumb(data, pathArray) {
 
   // const sectionBreadCrumb = div({ class: 'list l3-nav__menu-options--list first' }, ul());
   // ToDo: This width needs to be based on a calculation of the width of of the title
-  sectionBreadCrumb.querySelector('.list.l3-nav__menu-options--list.first').style.width = '197px';
+  sectionBreadCrumb.querySelector('.list.l3-nav__menu-options--list.first').style.width = data.links[0].width;
   for (const root of data.links) {
     const breadCrumbLink = a({ class: 'l3-nav__submenu', href: root.url });
     breadCrumbLink.innerHTML = root.label;
@@ -588,9 +600,10 @@ function populateBreadCrumb(data, pathArray) {
     for (const child of data.links[index].children) {
       const breadCrumbLink = a({ class: 'l3-nav__submenu', href: child.url });
       breadCrumbLink.innerHTML = child.label;
-      if (child.url === `/${pathArray.join('/')}`) {
+      if (child.url === `/${pathArray.join('/')}/`) {
         breadCrumbLink.classList.add('bold');
       }
+      subSectionBreadCrumb.style.width = data.links[index].width;
       subSectionBreadCrumb.querySelector('ul').appendChild(li(breadCrumbLink));
     }
     breadCrumb.querySelector('.sublist-container').appendChild(subSectionBreadCrumb);

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -489,115 +489,23 @@ function buildBreadCrumbMobile() {
   const breadCrumb = div({ class: 'l3-nav__mobile' });
   breadCrumb.innerHTML = `
         <div class="l3-nav__mobile--menu-head l3-nav__mobile--closed not-active">
-            <div class="left-sec">
-<!--            <a class="title-item" data-static-label="Unified Communications" aria-expanded="false" data-analytics-icmp="l3breadrumb|l3nav__Unified Communications" data-di-id="l3breadrumb|l3nav__Unified Communications" data-analytics-link-icmp="l3breadrumb|l3nav__Unified Communications">-->
-<!--            Unified Communications-->
-<!--            </a>-->
-<!--            <span class="separator">-->
-<!--            /-->
-<!--            </span>-->
-<!--            <a class="title-item" data-static-label="Features" aria-expanded="false" data-analytics-icmp="l3breadrumb|l3nav__Unified Communications_Features" data-di-id="l3breadrumb|l3nav__Unified Communications_Features" data-analytics-link-icmp="l3breadrumb|l3nav__Unified Communications_Features">-->
-<!--            Features-->
-<!--            </a>-->
-<!--            <span class="separator">-->
-<!--            /-->
-<!--            </span>-->
-<!--            <a class="title-item" data-static-label="Admin Portal" aria-expanded="false" data-analytics-icmp="l3breadrumb|l3nav__Unified Communications_Features_Admin Portal" data-di-id="l3breadrumb|l3nav__Unified Communications_Features_Admin Portal" data-analytics-link-icmp="l3breadrumb|l3nav__Unified Communications_Features_Admin Portal">-->
-<!--            Admin Portal-->
-<!--            </a>-->
-        </div>
+            <div class="left-sec"></div>
             <div class="right-sec">
-        <span class="Vlt-icon-chevron right-sec__dropdown-icn"></span>
-        </div>
+                <span class="Vlt-icon-chevron right-sec__dropdown-icn"></span>
+            </div>
         </div>
         <div class="l3-nav__mobile--menu-head l3-nav__mobile--open">
-            <div class="left-sec">
-        </div>
+            <div class="left-sec"></div>
             <div class="right-sec">
-        <span class="Vlt-icon-close right-sec__close-icn" style="left: -55px;"></span>
+                <span class="Vlt-icon-close right-sec__close-icn" style="left: -55px;"></span>
+            </div>
         </div>
-        </div>
-        
         <div class="l3-nav__mobile--menu-body active">
-        <div class="menu-sub-list">
-        
-<!--
-            </div>
-            <a class="title-item" data-analytics-icmp="l3nav2022|l3nav_Unified Communications_Features" aria-expanded="false" data-di-id="l3nav2022|l3nav_Unified Communications_Features" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features">
-            Features
-            </a>
-            <div class="menu-sub-list">
-            <ul>
-            <li>
-            <span>
-            <a href="/unified-communications/features/desktop/" data-static-label="Desktop" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Desktop" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Desktop" data-external="false">
-            Desktop
-            </a>
-            </span>
-            </li>
-            <li>
-            <span>
-            <a href="/unified-communications/features/vonage-meetings/" data-static-label="Vonage Meetings" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Vonage Meetings" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Vonage Meetings" data-external="false">
-            Vonage Meetings
-            </a>
-            </span>
-            </li>
-            <li>
-            <span>
-            <a class="active" href="/unified-communications/features/admin-portal/" data-static-label="Admin portal" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Admin portal" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Admin portal" data-external="false">
-             Admin portal
-            </a>
-            </span>
-            </li>
-            <li>
-            <span>
-            <a href="/unified-communications/features/business-sms/" data-static-label="Business SMS" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Business SMS" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Business SMS" data-external="false">
-            Business SMS
-            </a>
-            </span>
-            </li>
-            <li>
-            <span>
-            <a href="/unified-communications/features/paperless-fax/" data-static-label="Paperless fax" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Paperless fax" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Paperless fax" data-external="false">
-            Paperless fax
-            </a>
-            </span>
-            </li>
-            <li>
-            <span>
-            <a href="/unified-communications/features/mobile-app/" data-static-label="Mobile app" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Mobile app" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Mobile app" data-external="false">
-            Mobile app
-            </a>
-            </span>
-            </li>
-            <li>
-            <span>
-            <a href="/unified-communications/features/virtual-receptionist/" data-static-label="Virtual receptionist" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Virtual receptionist" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Virtual receptionist" data-external="false">
-            Virtual receptionist
-            </a>
-            </span>
-            </li>
-            <li>
-            <span>
-            <a href="/unified-communications/features/" data-static-label="View all features" data-di-id="l3nav2022|l3nav_Unified Communications_Features_View all features" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_View all features" data-external="false">
-            View all features
-            </a>
-            </span>
-            </li>
-            </ul>
-            </div>
-            <a class="title-item" data-analytics-icmp="l3nav2022|l3nav_Unified Communications_Features_Admin Portal" aria-expanded="false" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Admin Portal" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Admin Portal">
-            Admin Portal
-            </a>
--->
-        <a href="/unified-communications/pricing/" class="title-item" data-di-id="l3breadrumb|l3nav_ctalinks_seeplans&amp;pricing" data-analytics-link-icmp="l3breadrumb|l3nav_ctalinks_seeplans&amp;pricing" target="_self" data-external="false">
-        See plans &amp; pricing
-        </a>
-        <a href="tel:+1-855-430-6401" class="title-item" data-di-id="l3breadrumb|l3nav_ctalinks_1-855-430-6401" data-analytics-link-icmp="l3breadrumb|l3nav_ctalinks_1-855-430-6401" target="_self" data-external="false">
-        1-855-430-6401
-        </a>
-        </div>
-`;
+          <div class="menu-sub-list">
+            <a href="/unified-communications/pricing/" class="title-item" data-di-id="l3breadrumb|l3nav_ctalinks_seeplans&amp;pricing" data-analytics-link-icmp="l3breadrumb|l3nav_ctalinks_seeplans&amp;pricing" target="_self" data-external="false">See plans &amp; pricing</a>
+            <a href="tel:+1-855-430-6401" class="title-item" data-di-id="l3breadrumb|l3nav_ctalinks_1-855-430-6401" data-analytics-link-icmp="l3breadrumb|l3nav_ctalinks_1-855-430-6401" target="_self" data-external="false">1-855-430-6401</a>
+          </div>
+        </div>`;
   return breadCrumb;
 }
 /**
@@ -720,7 +628,7 @@ function populateBreadCrumb(data, pathArray) {
     breadCrumbDesktop.querySelector('.sublist-container').appendChild(subSectionBreadCrumbDesktop);
     breadCrumbMobile.querySelector('.menu-sub-list').appendChild(subSectionBreadCrumbMobile);
   }
-  if (data.titles[2] != '') {
+  if (data.titles[2] !== '') {
     breadCrumbMobile.querySelector('.menu-sub-list').appendChild(a({ class: 'title-item', innerHTML: data.titles[2] }));
   }
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,4 +1,7 @@
 import { getMetadata, decorateIcons, toClassName } from '../../scripts/lib-franklin.js';
+import {
+  a, div, li, ul,
+} from '../../scripts/scripts.js';
 
 /* ------------------------------ Global Variables ----------------------------------- */
 // media query match that indicates mobile/tablet width
@@ -94,6 +97,29 @@ function toggleNavSubSection(event) {
 }
 
 /* ------------------------------ Global Functions ----------------------------------- */
+
+function buildHierarchy(flat) {
+  // Array to build out with parent->child hierarchy for links
+  const structuredLinks = [];
+
+  // Iterate through the flat array of links
+  flat.forEach((item) => {
+    // If the link has no parent it's a top level node so append it to the top level array
+    if (item.parent === null || item.parent === '') {
+      structuredLinks.push(item);
+      // Add a children array property to the parent object
+      structuredLinks[structuredLinks.length - 1].children = [];
+    }
+    // Otherwise if the link has a listed parent find it in the array
+    // and append it to the child array element of that parent
+    else {
+      const index = structuredLinks.indexOf(structuredLinks.find((o) => o.url === item.parent));
+      structuredLinks[index].children.push(item);
+    }
+  });
+
+  return structuredLinks;
+}
 
 /**
  * A utility function to create divs with specified ID and classes
@@ -430,6 +456,135 @@ function buildHamburger(nav, navSections) {
   return hamburger;
 }
 
+/**
+ * Build the hamburger icon element which will trigger the menu display in mobile mode
+ * @returns {HTMLDivElement} Breadcrumb header element
+ // * @param {String} title The content of the root breadcrumb element that should be displayed (page section)
+ // * @param {[Object]} links An array of link objects sorted in a parent -> child structure
+ */
+function buildBreadCrumb() {
+  const breadCrumb = div({ class: 'nav-breadcrumb-wrapper' });
+  breadCrumb.innerHTML = `
+    <div class="container section-container">
+      <div class="left-sec" tabindex="0">
+        <div class="l3-nav__menu-title">
+          <span class="title-option">
+          <!-- This a link needs to have it's name and url dynamically populated            -->
+            <a class="title-option__l3nav active" data-static-label="Unified Communications">
+              <span class="nav-icon Vlt-icon-phone"></span>
+              <span>Unified Communications</span>
+            </a>
+          </span>
+          <span class="Vlt-icon-chevron arrow-icn"></span>
+        </div>
+        <div class="menu-option-sublist l3-nav__menu-options">
+          <div class="container sublist-container"></div>
+        </div>
+      </div>
+      <div class="right-sec">
+        <div class="right-sec__menu-option">
+          <a href="/unified-communications/pricing/" class="title-option" target="_self">
+          See plans &amp; pricing
+          </a>
+        </div>
+      <div class="right-sec__menu-option">
+        <a href="tel:+1-855-430-6401" class="title-option" target="_self">
+        1-855-430-6401
+        </a>
+      </div>
+      </div>
+    </div>`;
+  return breadCrumb;
+}
+
+/**
+ *
+ * @param {HTMLDivElement} container The div element in the breadcrumb which will receive the links
+ * @param {[Object]} links An array of link objects sorted in a parent -> child structure
+ */
+function populateBreadCrumb(container, links) {
+  const parentBreadCrumb = div({ class: 'list l3-nav__menu-options--list first' }, ul());
+  parentBreadCrumb.style.width = '225px';
+  for (const root of links) {
+    const breadCrumbLink = a({ class: 'l3-nav__submenu', href: root.url });
+    breadCrumbLink.innerHTML = root.label;
+    parentBreadCrumb.querySelector('ul').appendChild(li(breadCrumbLink));
+  }
+
+  container.appendChild(parentBreadCrumb);
+
+  // TODO: Need to add logic here that determines whether we are in one of the sections and if so create a secondary div and append it
+  //
+  // <div className="list l3-nav__menu-options--list first" style="width: 225px;">
+  //   <ul>
+  //     <li>
+  //       <a className="l3-nav__submenu active"
+  //          href="/unified-communications/?icmp=l3breadrumb|l3nav_unifiedcommunications_overview"
+  //          data-static-label="Overview" data-di-id="l3breadrumb|l3nav_unifiedcommunications_overview"
+  //          data-external="false">
+  //         Overview
+  //       </a>
+  //     </li>
+  //     <li>
+  //       <a className="l3-nav__submenu "
+  //          href="/unified-communications/platform/?icmp=l3breadrumb|l3nav_unifiedcommunications_platform"
+  //          data-static-label="Platform" data-di-id="l3breadrumb|l3nav_unifiedcommunications_platform"
+  //          data-external="false">
+  //         Platform
+  //       </a>
+  //     </li>
+  //     <li>
+  //       <a className="l3-nav__submenu "
+  //          href="/unified-communications/features/?icmp=l3breadrumb|l3nav_unifiedcommunications_features"
+  //          data-static-label="Features" data-di-id="l3breadrumb|l3nav_unifiedcommunications_features"
+  //          data-external="false">
+  //         Features
+  //       </a>
+  //     </li>
+  //     <li>
+  //       <a className="l3-nav__submenu "
+  //          href="/unified-communications/call-center/?icmp=l3breadrumb|l3nav_unifiedcommunications_callcenter"
+  //          data-static-label="Call Center" data-di-id="l3breadrumb|l3nav_unifiedcommunications_callcenter"
+  //          data-external="false">
+  //         Call Center
+  //       </a>
+  //     </li>
+  //     <li>
+  //       <a className="l3-nav__submenu "
+  //          href="/unified-communications/use-cases/?icmp=l3breadrumb|l3nav_unifiedcommunications_usecases"
+  //          data-static-label="Use Cases" data-di-id="l3breadrumb|l3nav_unifiedcommunications_usecases"
+  //          data-external="false">
+  //         Use Cases
+  //       </a>
+  //     </li>
+  //     <li>
+  //       <a className="l3-nav__submenu "
+  //          href="/unified-communications/integrations/?icmp=l3breadrumb|l3nav_unifiedcommunications_integrations"
+  //          data-static-label="Integrations" data-di-id="l3breadrumb|l3nav_unifiedcommunications_integrations"
+  //          data-external="false">
+  //         Integrations
+  //       </a>
+  //     </li>
+  //     <li>
+  //
+  //       <a className="l3-nav__submenu "
+  //          href="/unified-communications/global/?icmp=l3breadrumb|l3nav_unifiedcommunications_international"
+  //          data-static-label="International" data-di-id="l3breadrumb|l3nav_unifiedcommunications_international"
+  //          data-external="false">
+  //         International
+  //       </a>
+  //     </li>
+  //     <li>
+  //       <a className="l3-nav__submenu "
+  //          href="/unified-communications/pricing/?icmp=l3breadrumb|l3nav_unifiedcommunications_pricing"
+  //          data-static-label="Pricing" data-di-id="l3breadrumb|l3nav_unifiedcommunications_pricing"
+  //          data-external="false">
+  //         Pricing
+  //       </a>
+  //     </li>
+  //   </ul>
+  // </div>
+}
 /* ------------------------------ Main function invoked at load ------------------------------- */
 
 /**
@@ -517,5 +672,18 @@ export default async function decorate(block) {
     const headerBackdrop = createDiv('backdrop', ['header', 'backdrop']);
     block.append(headerBackdrop);
     block.append(navWrapper);
+    block.append(buildBreadCrumb());
+  }
+
+  const navSectionPath = getMetadata('navsection');
+  const subNavResp = await fetch(`/sub-nav/${navSectionPath}.json`);
+  if (subNavResp.ok) {
+    const json = await subNavResp.text();
+    const subNavs = JSON.parse(json);
+
+    const subNavsContainer = document.querySelector('.nav-breadcrumb-wrapper .sublist-container');
+
+    const breadCrumbLinks = buildHierarchy(subNavs.data);
+    populateBreadCrumb(subNavsContainer, breadCrumbLinks);
   }
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -27,10 +27,8 @@ function scrollFunction() {
   if (window.location.pathname.search('unified-communications/')) {
     if ((scrolledDown && document.body.scrollTop > scrollDistance)
       || (scrolledDown && document.documentElement.scrollTop > scrollDistance)) {
-      document.querySelector('.nav-wrapper').style.display = 'none';
       document.querySelector('.header-wrapper').classList.add('collapsed');
     } else {
-      document.querySelector('.nav-wrapper').style.display = '';
       document.querySelector('.header-wrapper').classList.remove('collapsed');
     }
   }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -109,6 +109,9 @@ function toggleNavSubSection(event) {
 
 function toggleBreadCrumb() {
   document.querySelector('.menu-option-sublist.l3-nav__menu-options').classList.toggle('active');
+  document.querySelector('.l3-nav__mobile--menu-body').classList.toggle('active');
+  document.querySelector('.l3-nav__mobile--menu-head.l3-nav__mobile--closed').classList.toggle('not-active');
+  document.querySelector('.l3-nav__mobile--menu-head.l3-nav__mobile--open').classList.toggle('not-active');
 }
 
 /* ------------------------------ Global Functions ----------------------------------- */
@@ -220,6 +223,10 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
   toggleAllNavSections(navSections, expanded || isDesktop.matches ? 'false' : 'true');
   button.setAttribute('aria-label', expanded ? 'Open navigation' : 'Close navigation');
 
+  const mobileBreadCrumb = document.querySelector('.l3-nav__mobile');
+  if (mobileBreadCrumb) {
+    mobileBreadCrumb.style.display = expanded ? 'block' : 'none';
+  }
   // enable nav dropdown keyboard accessibility
   const navDrops = navSections.querySelectorAll('.nav-drop');
   if (isDesktop.matches) {
@@ -488,24 +495,19 @@ function buildBreadCrumbDesktop() {
 function buildBreadCrumbMobile() {
   const breadCrumb = div({ class: 'l3-nav__mobile' });
   breadCrumb.innerHTML = `
-        <div class="l3-nav__mobile--menu-head l3-nav__mobile--closed not-active">
+        <div class="l3-nav__mobile--menu-head l3-nav__mobile--closed">
             <div class="left-sec"></div>
             <div class="right-sec">
                 <span class="Vlt-icon-chevron right-sec__dropdown-icn"></span>
             </div>
         </div>
-        <div class="l3-nav__mobile--menu-head l3-nav__mobile--open">
+        <div class="l3-nav__mobile--menu-head l3-nav__mobile--open not-active">
             <div class="left-sec"></div>
             <div class="right-sec">
                 <span class="Vlt-icon-close right-sec__close-icn" style="left: -55px;"></span>
             </div>
         </div>
-        <div class="l3-nav__mobile--menu-body active">
-          <div class="menu-sub-list">
-            <a href="/unified-communications/pricing/" class="title-item" data-di-id="l3breadrumb|l3nav_ctalinks_seeplans&amp;pricing" data-analytics-link-icmp="l3breadrumb|l3nav_ctalinks_seeplans&amp;pricing" target="_self" data-external="false">See plans &amp; pricing</a>
-            <a href="tel:+1-855-430-6401" class="title-item" data-di-id="l3breadrumb|l3nav_ctalinks_1-855-430-6401" data-analytics-link-icmp="l3breadrumb|l3nav_ctalinks_1-855-430-6401" target="_self" data-external="false">1-855-430-6401</a>
-          </div>
-        </div>`;
+        <div class="l3-nav__mobile--menu-body"></div>`;
   return breadCrumb;
 }
 /**
@@ -556,7 +558,8 @@ function populateBreadCrumb(data, pathArray) {
     breadCrumbTitleElemDesktop.addEventListener('click', toggleBreadCrumb);
     breadCrumbDesktop.querySelector('.left-sec').appendChild(breadCrumbTitleElemDesktop);
     breadCrumbMobile.querySelector('.l3-nav__mobile--closed .left-sec').appendChild(a({ class: 'title-item', innerHTML: title }));
-
+    breadCrumbMobile.querySelector('.Vlt-icon-close.right-sec__close-icn').addEventListener('click', toggleBreadCrumb);
+    breadCrumbMobile.querySelector('.Vlt-icon-chevron.right-sec__dropdown-icn').addEventListener('click', toggleBreadCrumb);
     if (index === 0) {
       // Add an icon for decoration in the desktop title
       const iconSpan = span({ class: 'nav-icon Vlt-icon-phone' });
@@ -590,7 +593,7 @@ function populateBreadCrumb(data, pathArray) {
 
   sectionBreadCrumbDesktop.querySelector('.list.l3-nav__menu-options--list.first').style.width = data.links[0].width;
 
-  const sectionBreadCrumbMobile = ul();
+  const sectionBreadCrumbMobile = div({ class: 'menu-sub-list' }, ul());
 
   data.links.forEach((root) => {
     const breadCrumbLink = a({ class: 'l3-nav__submenu', href: root.url, innerHTML: root.label });
@@ -598,19 +601,19 @@ function populateBreadCrumb(data, pathArray) {
       breadCrumbLink.classList.add('bold');
     }
     sectionBreadCrumbDesktop.querySelector('ul').appendChild(li(breadCrumbLink));
-    sectionBreadCrumbMobile.appendChild(li(span(breadCrumbLink)));
+    sectionBreadCrumbMobile.querySelector('ul').appendChild(li(span(breadCrumbLink.cloneNode(true))));
   });
 
   breadCrumbDesktop.querySelector('.left-sec').appendChild(sectionBreadCrumbDesktop);
-  breadCrumbMobile.querySelector('.menu-sub-list').appendChild(sectionBreadCrumbMobile);
+  breadCrumbMobile.querySelector('.l3-nav__mobile--menu-body').appendChild(sectionBreadCrumbMobile.cloneNode(true));
 
   // If the page is a subsection based on its section metadata
   // need to load the relevant subsection breadcrumb data
   if (inSubSection) {
-    breadCrumbMobile.querySelector('.menu-sub-list').appendChild(a({ class: 'title-item', innerHTML: data.titles[1] }));
+    breadCrumbMobile.querySelector('.l3-nav__mobile--menu-body').appendChild(a({ class: 'title-item', innerHTML: data.titles[1] }));
     const subSection = `/${pathArray[0]}/${pathArray[1]}/`;
     const subSectionBreadCrumbDesktop = div({ class: 'list l3-nav__menu-options--list' }, ul());
-    const subSectionBreadCrumbMobile = ul();
+    const subSectionBreadCrumbMobile = div({ class: 'menu-sub-list' }, ul());
 
     // Find the index in the linksData data of the root page we are currently on given the section metadata
     const index = data.links.indexOf(data.links.find((o) => o.url === subSection));
@@ -622,15 +625,22 @@ function populateBreadCrumb(data, pathArray) {
       }
       subSectionBreadCrumbDesktop.style.width = data.links[index].width;
       subSectionBreadCrumbDesktop.querySelector('ul').appendChild(li(breadCrumbLink));
-      subSectionBreadCrumbMobile.appendChild(li(span(breadCrumbLink)));
+      subSectionBreadCrumbMobile.querySelector('ul').appendChild(li(span(breadCrumbLink.cloneNode(true))));
     });
 
     breadCrumbDesktop.querySelector('.sublist-container').appendChild(subSectionBreadCrumbDesktop);
-    breadCrumbMobile.querySelector('.menu-sub-list').appendChild(subSectionBreadCrumbMobile);
+    breadCrumbMobile.querySelector('.l3-nav__mobile--menu-body').appendChild(subSectionBreadCrumbMobile);
   }
-  if (data.titles[2] !== '') {
-    breadCrumbMobile.querySelector('.menu-sub-list').appendChild(a({ class: 'title-item', innerHTML: data.titles[2] }));
+  if (data.titles.length > 2) {
+    breadCrumbMobile.querySelector('.l3-nav__mobile--menu-body').appendChild(a({ class: 'title-item', innerHTML: data.titles[2] }));
   }
+
+  const contactSection = div({ class: 'menu-sub-list' });
+  contactSection.innerHTML = `
+        <a href="/unified-communications/pricing/" class="title-item" target="_self" data-external="false">See plans &amp; pricing</a>
+        <a href="tel:+1-855-430-6401" class="title-item" target="_self" data-external="false">1-855-430-6401</a>`;
+
+  breadCrumbMobile.querySelector('.l3-nav__mobile--menu-body').append(contactSection);
 }
 
 /* ------------------------------ Main function invoked at load ------------------------------- */

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -589,7 +589,7 @@ function populateBreadCrumb(data, pathArray) {
       div({ class: 'list l3-nav-menu-options-list first' },
         ul())));
 
-  sectionBreadCrumbDesktop.querySelector('.list.l3-nav-menu-options-list.first').style.width = data.links[0].width;
+  sectionBreadCrumbDesktop.querySelector('.list.l3-nav-menu-options-list.first').style.width = data.links[0].width ? data.links[0].width : '100px';
 
   const sectionBreadCrumbMobile = div({ class: 'menu-sub-list' }, ul());
 
@@ -621,7 +621,7 @@ function populateBreadCrumb(data, pathArray) {
       if (child.url === `/${pathArray.join('/')}/`) {
         breadCrumbLink.classList.add('bold');
       }
-      subSectionBreadCrumbDesktop.style.width = data.links[index].width;
+      subSectionBreadCrumbDesktop.style.width = data.links[index].width ? data.links[index].width : '100px';
       subSectionBreadCrumbDesktop.querySelector('ul').appendChild(li(breadCrumbLink));
       subSectionBreadCrumbMobile.querySelector('ul').appendChild(li(span(breadCrumbLink.cloneNode(true))));
     });

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -108,10 +108,10 @@ function toggleNavSubSection(event) {
 }
 
 function toggleBreadCrumb() {
-  document.querySelector('.menu-option-sublist.l3-nav__menu-options').classList.toggle('active');
-  document.querySelector('.l3-nav__mobile--menu-body').classList.toggle('active');
-  document.querySelector('.l3-nav__mobile--menu-head.l3-nav__mobile--closed').classList.toggle('not-active');
-  document.querySelector('.l3-nav__mobile--menu-head.l3-nav__mobile--open').classList.toggle('not-active');
+  document.querySelector('.menu-option-sublist.l3-nav-menu-options').classList.toggle('active');
+  document.querySelector('.l3-nav-mobile-menu-body').classList.toggle('active');
+  document.querySelector('.l3-nav-mobile-menu-head.l3-nav-mobile-closed').classList.toggle('not-active');
+  document.querySelector('.l3-nav-mobile-menu-head.l3-nav-mobile-open').classList.toggle('not-active');
 }
 
 /* ------------------------------ Global Functions ----------------------------------- */
@@ -223,7 +223,7 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
   toggleAllNavSections(navSections, expanded || isDesktop.matches ? 'false' : 'true');
   button.setAttribute('aria-label', expanded ? 'Open navigation' : 'Close navigation');
 
-  const mobileBreadCrumb = document.querySelector('.l3-nav__mobile');
+  const mobileBreadCrumb = document.querySelector('.l3-nav-mobile');
   if (mobileBreadCrumb) {
     mobileBreadCrumb.style.display = expanded ? 'block' : 'none';
   }
@@ -471,18 +471,18 @@ function buildHamburger(nav, navSections) {
  // * @param {[Object]} links An array of link objects sorted in a parent -> child structure
  */
 function buildBreadCrumbDesktop() {
-  const breadCrumb = div({ class: 'l3-nav__desktop' }, div({ class: 'l3-nav__desktop--menu-head' }));
+  const breadCrumb = div({ class: 'l3-nav-desktop' }, div({ class: 'l3-nav-desktop-menu-head' }));
   breadCrumb.innerHTML = `
     <div class="container section-container">
       <div class="left-sec" tabindex="0">
       </div>
       <div class="right-sec">
-        <div class="right-sec__menu-option">
+        <div class="right-sec-menu-option">
           <a href="/unified-communications/pricing/" class="title-option" target="_self">
           See plans &amp; pricing
           </a>
         </div>
-      <div class="right-sec__menu-option">
+      <div class="right-sec-menu-option">
         <a href="tel:+1-855-430-6401" class="title-option" target="_self">
         1-855-430-6401
         </a>
@@ -493,21 +493,21 @@ function buildBreadCrumbDesktop() {
 }
 
 function buildBreadCrumbMobile() {
-  const breadCrumb = div({ class: 'l3-nav__mobile' });
+  const breadCrumb = div({ class: 'l3-nav-mobile' });
   breadCrumb.innerHTML = `
-        <div class="l3-nav__mobile--menu-head l3-nav__mobile--closed">
+        <div class="l3-nav-mobile-menu-head l3-nav-mobile-closed">
             <div class="left-sec"></div>
             <div class="right-sec">
-                <span class="Vlt-icon-chevron right-sec__dropdown-icn"></span>
+                <span class="vlt-icon-chevron right-sec-dropdown-icn"></span>
             </div>
         </div>
-        <div class="l3-nav__mobile--menu-head l3-nav__mobile--open not-active">
+        <div class="l3-nav-mobile-menu-head l3-nav-mobile-open not-active">
             <div class="left-sec"></div>
             <div class="right-sec">
-                <span class="Vlt-icon-close right-sec__close-icn" style="left: -55px;"></span>
+                <span class="vlt-icon-close right-sec-close-icn" style="left: -55px;"></span>
             </div>
         </div>
-        <div class="l3-nav__mobile--menu-body"></div>`;
+        <div class="l3-nav-mobile-menu-body"></div>`;
   return breadCrumb;
 }
 /**
@@ -542,61 +542,61 @@ function parseBreadCrumbJSON(json) {
 
  */
 function populateBreadCrumb(data, pathArray) {
-  const breadCrumbDesktop = document.querySelector('.l3-nav__desktop');
-  const breadCrumbMobile = document.querySelector('.l3-nav__mobile');
+  const breadCrumbDesktop = document.querySelector('.l3-nav-desktop');
+  const breadCrumbMobile = document.querySelector('.l3-nav-mobile');
   const inSubSection = (data.titles.length > 1);
 
   // Build out the breadcrumb titles based on the nav-titles in the pages metadata
-  // ToDo: Split this off into a separate function to build the title element
   data.titles.forEach((title, index) => {
-    const breadCrumbTitleElemDesktop = div({ class: 'l3-nav__menu-title' });
-    breadCrumbTitleElemDesktop.innerHTML = `<span class="title-option">
-    <a class="title-option__l3nav" data-static-label="${title}">
+    const breadCrumbTitleElemDesktop = div({ class: 'l3-nav-menu-title' });
+    breadCrumbTitleElemDesktop.innerHTML = `
+        <span class="title-option">
+            <a class="title-option-l3nav" data-static-label="${title}">
               <span>${title}</span>
             </a>
           </span>`;
     breadCrumbTitleElemDesktop.addEventListener('click', toggleBreadCrumb);
     breadCrumbDesktop.querySelector('.left-sec').appendChild(breadCrumbTitleElemDesktop);
-    breadCrumbMobile.querySelector('.l3-nav__mobile--closed .left-sec').appendChild(a({ class: 'title-item', innerHTML: title }));
-    breadCrumbMobile.querySelector('.Vlt-icon-close.right-sec__close-icn').addEventListener('click', toggleBreadCrumb);
-    breadCrumbMobile.querySelector('.Vlt-icon-chevron.right-sec__dropdown-icn').addEventListener('click', toggleBreadCrumb);
+    breadCrumbMobile.querySelector('.l3-nav-mobile-closed .left-sec').appendChild(a({ class: 'title-item', innerHTML: title }));
+    breadCrumbMobile.querySelector('.vlt-icon-close.right-sec-close-icn').addEventListener('click', toggleBreadCrumb);
+    breadCrumbMobile.querySelector('.vlt-icon-chevron.right-sec-dropdown-icn').addEventListener('click', toggleBreadCrumb);
+
     if (index === 0) {
       // Add an icon for decoration in the desktop title
-      const iconSpan = span({ class: 'nav-icon Vlt-icon-phone' });
+      const iconSpan = span({ class: 'nav-icon vlt-icon-phone' });
       breadCrumbTitleElemDesktop.querySelector('a').prepend(iconSpan);
 
-      // Add the first link for the open mobile breadcrumb
-      breadCrumbMobile.querySelector('.l3-nav__mobile--open .left-sec').appendChild(a({ class: 'title-item', innerHTML: title }));
+      // Add only the first link for the open mobile breadcrumb
+      breadCrumbMobile.querySelector('.l3-nav-mobile-open .left-sec').appendChild(a({ class: 'title-item', innerHTML: title }));
     }
 
     // If there is more than one breadcrumb title, and we aren't on the last
     if (index !== data.titles.length - 1 && data.titles.length > 1) {
-      // Add a separator for the desktop breadcrumb
-      breadCrumbDesktop.querySelector('.left-sec .l3-nav__menu-title:last-child').appendChild(span({ class: 'separator', innerHTML: '/' }));
-      breadCrumbMobile.querySelector('.l3-nav__mobile--closed .left-sec').appendChild(span({ class: 'separator', innerHTML: '/' }));
+      // Add a separator for the breadcrumb titles
+      breadCrumbDesktop.querySelector('.left-sec .l3-nav-menu-title:last-child').appendChild(span({ class: 'separator', innerHTML: '/' }));
+      breadCrumbMobile.querySelector('.l3-nav-mobile-closed .left-sec').appendChild(span({ class: 'separator', innerHTML: '/' }));
     }
 
     // If this is the last title in the breadcrumb
     if (index === data.titles.length - 1) {
       // Add a trailing chevron decoration
-      const chevron = span({ class: 'Vlt-icon-chevron arrow-icn' });
-      breadCrumbDesktop.querySelector('.l3-nav__menu-title:last-child .title-option__l3nav').classList.add('boldbreadCrumbTitle');
-      breadCrumbDesktop.querySelector('.l3-nav__menu-title:last-child').appendChild(chevron);
+      const chevron = span({ class: 'vlt-icon-chevron arrow-icn' });
+      breadCrumbDesktop.querySelector('.l3-nav-menu-title:last-child .title-option-l3nav').classList.add('bold');
+      breadCrumbDesktop.querySelector('.l3-nav-menu-title:last-child').appendChild(chevron);
     }
   });
 
-  // ToDo: Split this off into a separate function to build the section element
-  const sectionBreadCrumbDesktop = div({ class: 'menu-option-sublist l3-nav__menu-options' },
+  const sectionBreadCrumbDesktop = div({ class: 'menu-option-sublist l3-nav-menu-options' },
     div({ class: 'container sublist-container' },
-      div({ class: 'list l3-nav__menu-options--list first' },
+      div({ class: 'list l3-nav-menu-options-list first' },
         ul())));
 
-  sectionBreadCrumbDesktop.querySelector('.list.l3-nav__menu-options--list.first').style.width = data.links[0].width;
+  sectionBreadCrumbDesktop.querySelector('.list.l3-nav-menu-options-list.first').style.width = data.links[0].width;
 
   const sectionBreadCrumbMobile = div({ class: 'menu-sub-list' }, ul());
 
   data.links.forEach((root) => {
-    const breadCrumbLink = a({ class: 'l3-nav__submenu', href: root.url, innerHTML: root.label });
+    const breadCrumbLink = a({ class: 'l3-nav-submenu', href: root.url, innerHTML: root.label });
     if (root.url === `/${pathArray.join('/')}`) {
       breadCrumbLink.classList.add('bold');
     }
@@ -605,21 +605,21 @@ function populateBreadCrumb(data, pathArray) {
   });
 
   breadCrumbDesktop.querySelector('.left-sec').appendChild(sectionBreadCrumbDesktop);
-  breadCrumbMobile.querySelector('.l3-nav__mobile--menu-body').appendChild(sectionBreadCrumbMobile.cloneNode(true));
+  breadCrumbMobile.querySelector('.l3-nav-mobile-menu-body').appendChild(sectionBreadCrumbMobile.cloneNode(true));
 
   // If the page is a subsection based on its section metadata
   // need to load the relevant subsection breadcrumb data
   if (inSubSection) {
-    breadCrumbMobile.querySelector('.l3-nav__mobile--menu-body').appendChild(a({ class: 'title-item', innerHTML: data.titles[1] }));
+    breadCrumbMobile.querySelector('.l3-nav-mobile-menu-body').appendChild(a({ class: 'title-item', innerHTML: data.titles[1] }));
     const subSection = `/${pathArray[0]}/${pathArray[1]}/`;
-    const subSectionBreadCrumbDesktop = div({ class: 'list l3-nav__menu-options--list' }, ul());
+    const subSectionBreadCrumbDesktop = div({ class: 'list l3-nav-menu-options-list' }, ul());
     const subSectionBreadCrumbMobile = div({ class: 'menu-sub-list' }, ul());
 
     // Find the index in the linksData data of the root page we are currently on given the section metadata
     const index = data.links.indexOf(data.links.find((o) => o.url === subSection));
 
     data.links[index].children.forEach((child) => {
-      const breadCrumbLink = a({ class: 'l3-nav__submenu', href: child.url, innerHTML: child.label });
+      const breadCrumbLink = a({ class: 'l3-nav-submenu', href: child.url, innerHTML: child.label });
       if (child.url === `/${pathArray.join('/')}/`) {
         breadCrumbLink.classList.add('bold');
       }
@@ -629,18 +629,21 @@ function populateBreadCrumb(data, pathArray) {
     });
 
     breadCrumbDesktop.querySelector('.sublist-container').appendChild(subSectionBreadCrumbDesktop);
-    breadCrumbMobile.querySelector('.l3-nav__mobile--menu-body').appendChild(subSectionBreadCrumbMobile);
-  }
-  if (data.titles.length > 2) {
-    breadCrumbMobile.querySelector('.l3-nav__mobile--menu-body').appendChild(a({ class: 'title-item', innerHTML: data.titles[2] }));
+    breadCrumbMobile.querySelector('.l3-nav-mobile-menu-body').appendChild(subSectionBreadCrumbMobile);
   }
 
+  // If we are on a page of a subsection (three levels down) append the page title to the bottom of the mobile breadcrumb menu
+  if (data.titles.length > 2) {
+    breadCrumbMobile.querySelector('.l3-nav-mobile-menu-body').appendChild(a({ class: 'title-item', innerHTML: data.titles[2] }));
+  }
+
+  // Finally append the contact info to the mobile breadcrumb body
   const contactSection = div({ class: 'menu-sub-list' });
   contactSection.innerHTML = `
         <a href="/unified-communications/pricing/" class="title-item" target="_self" data-external="false">See plans &amp; pricing</a>
         <a href="tel:+1-855-430-6401" class="title-item" target="_self" data-external="false">1-855-430-6401</a>`;
 
-  breadCrumbMobile.querySelector('.l3-nav__mobile--menu-body').append(contactSection);
+  breadCrumbMobile.querySelector('.l3-nav-mobile-menu-body').append(contactSection);
 }
 
 /* ------------------------------ Main function invoked at load ------------------------------- */
@@ -742,10 +745,15 @@ export default async function decorate(block) {
   }
 
   const pathArray = sectionPathFull.split('/');
-  // TODO: Implement a guard on a null array
-  const subNavResp = await fetch(`/sub-nav/${pathArray[0]}.json`);
-  if (subNavResp.ok) {
-    const json = await subNavResp.text();
-    populateBreadCrumb(parseBreadCrumbJSON(json), pathArray);
+  if (pathArray.length > 0) {
+    const subNavResp = await fetch(`/sub-nav/${pathArray[0]}.json`);
+    if (subNavResp.ok) {
+      const json = await subNavResp.text();
+      populateBreadCrumb(parseBreadCrumbJSON(json), pathArray);
+    } else {
+      // If not on a subpath (main vonage.com site) don't show a breadcrumb (won't need it for VIP Project)
+      document.querySelector('.l3-nav-desktop').remove();
+      document.querySelector('.l3-nav-mobile').remove();
+    }
   }
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -463,8 +463,8 @@ function buildHamburger(nav, navSections) {
  // * @param {String} title The content of the root breadcrumb element that should be displayed (page section)
  // * @param {[Object]} links An array of link objects sorted in a parent -> child structure
  */
-function buildBreadCrumb() {
-  const breadCrumb = div({ class: 'nav-breadcrumb-wrapper' });
+function buildBreadCrumbDesktop() {
+  const breadCrumb = div({ class: 'l3-nav__desktop' }, div({ class: 'l3-nav__desktop--menu-head' }));
   breadCrumb.innerHTML = `
     <div class="container section-container">
       <div class="left-sec" tabindex="0">
@@ -485,6 +485,121 @@ function buildBreadCrumb() {
   return breadCrumb;
 }
 
+function buildBreadCrumbMobile() {
+  const breadCrumb = div({ class: 'l3-nav__mobile' });
+  breadCrumb.innerHTML = `
+        <div class="l3-nav__mobile--menu-head l3-nav__mobile--closed not-active">
+            <div class="left-sec">
+<!--            <a class="title-item" data-static-label="Unified Communications" aria-expanded="false" data-analytics-icmp="l3breadrumb|l3nav__Unified Communications" data-di-id="l3breadrumb|l3nav__Unified Communications" data-analytics-link-icmp="l3breadrumb|l3nav__Unified Communications">-->
+<!--            Unified Communications-->
+<!--            </a>-->
+<!--            <span class="separator">-->
+<!--            /-->
+<!--            </span>-->
+<!--            <a class="title-item" data-static-label="Features" aria-expanded="false" data-analytics-icmp="l3breadrumb|l3nav__Unified Communications_Features" data-di-id="l3breadrumb|l3nav__Unified Communications_Features" data-analytics-link-icmp="l3breadrumb|l3nav__Unified Communications_Features">-->
+<!--            Features-->
+<!--            </a>-->
+<!--            <span class="separator">-->
+<!--            /-->
+<!--            </span>-->
+<!--            <a class="title-item" data-static-label="Admin Portal" aria-expanded="false" data-analytics-icmp="l3breadrumb|l3nav__Unified Communications_Features_Admin Portal" data-di-id="l3breadrumb|l3nav__Unified Communications_Features_Admin Portal" data-analytics-link-icmp="l3breadrumb|l3nav__Unified Communications_Features_Admin Portal">-->
+<!--            Admin Portal-->
+<!--            </a>-->
+        </div>
+            <div class="right-sec">
+        <span class="Vlt-icon-chevron right-sec__dropdown-icn"></span>
+        </div>
+        </div>
+        <div class="l3-nav__mobile--menu-head l3-nav__mobile--open">
+            <div class="left-sec">
+        </div>
+            <div class="right-sec">
+        <span class="Vlt-icon-close right-sec__close-icn" style="left: -55px;"></span>
+        </div>
+        </div>
+        
+        <div class="l3-nav__mobile--menu-body active">
+        <div class="menu-sub-list">
+        
+<!--
+            </div>
+            <a class="title-item" data-analytics-icmp="l3nav2022|l3nav_Unified Communications_Features" aria-expanded="false" data-di-id="l3nav2022|l3nav_Unified Communications_Features" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features">
+            Features
+            </a>
+            <div class="menu-sub-list">
+            <ul>
+            <li>
+            <span>
+            <a href="/unified-communications/features/desktop/" data-static-label="Desktop" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Desktop" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Desktop" data-external="false">
+            Desktop
+            </a>
+            </span>
+            </li>
+            <li>
+            <span>
+            <a href="/unified-communications/features/vonage-meetings/" data-static-label="Vonage Meetings" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Vonage Meetings" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Vonage Meetings" data-external="false">
+            Vonage Meetings
+            </a>
+            </span>
+            </li>
+            <li>
+            <span>
+            <a class="active" href="/unified-communications/features/admin-portal/" data-static-label="Admin portal" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Admin portal" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Admin portal" data-external="false">
+             Admin portal
+            </a>
+            </span>
+            </li>
+            <li>
+            <span>
+            <a href="/unified-communications/features/business-sms/" data-static-label="Business SMS" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Business SMS" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Business SMS" data-external="false">
+            Business SMS
+            </a>
+            </span>
+            </li>
+            <li>
+            <span>
+            <a href="/unified-communications/features/paperless-fax/" data-static-label="Paperless fax" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Paperless fax" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Paperless fax" data-external="false">
+            Paperless fax
+            </a>
+            </span>
+            </li>
+            <li>
+            <span>
+            <a href="/unified-communications/features/mobile-app/" data-static-label="Mobile app" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Mobile app" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Mobile app" data-external="false">
+            Mobile app
+            </a>
+            </span>
+            </li>
+            <li>
+            <span>
+            <a href="/unified-communications/features/virtual-receptionist/" data-static-label="Virtual receptionist" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Virtual receptionist" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Virtual receptionist" data-external="false">
+            Virtual receptionist
+            </a>
+            </span>
+            </li>
+            <li>
+            <span>
+            <a href="/unified-communications/features/" data-static-label="View all features" data-di-id="l3nav2022|l3nav_Unified Communications_Features_View all features" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_View all features" data-external="false">
+            View all features
+            </a>
+            </span>
+            </li>
+            </ul>
+            </div>
+            <a class="title-item" data-analytics-icmp="l3nav2022|l3nav_Unified Communications_Features_Admin Portal" aria-expanded="false" data-di-id="l3nav2022|l3nav_Unified Communications_Features_Admin Portal" data-analytics-link-icmp="l3nav2022|l3nav_Unified Communications_Features_Admin Portal">
+            Admin Portal
+            </a>
+-->
+        <a href="/unified-communications/pricing/" class="title-item" data-di-id="l3breadrumb|l3nav_ctalinks_seeplans&amp;pricing" data-analytics-link-icmp="l3breadrumb|l3nav_ctalinks_seeplans&amp;pricing" target="_self" data-external="false">
+        See plans &amp; pricing
+        </a>
+        <a href="tel:+1-855-430-6401" class="title-item" data-di-id="l3breadrumb|l3nav_ctalinks_1-855-430-6401" data-analytics-link-icmp="l3breadrumb|l3nav_ctalinks_1-855-430-6401" target="_self" data-external="false">
+        1-855-430-6401
+        </a>
+        </div>
+`;
+  return breadCrumb;
+}
 /**
  *
  * @param {String} json The json response returned for the nav hierarchy data to use when building the breadcrumb of the header
@@ -517,82 +632,99 @@ function parseBreadCrumbJSON(json) {
 
  */
 function populateBreadCrumb(data, pathArray) {
-  const breadCrumb = document.querySelector('.nav-breadcrumb-wrapper');
+  const breadCrumbDesktop = document.querySelector('.l3-nav__desktop');
+  const breadCrumbMobile = document.querySelector('.l3-nav__mobile');
   const inSubSection = (data.titles.length > 1);
 
   // Build out the breadcrumb titles based on the nav-titles in the pages metadata
+  // ToDo: Split this off into a separate function to build the title element
   data.titles.forEach((title, index) => {
-    // If this is the first breadcrumb element, need to start with the icon span
-    const breadCrumbTitleElem = div({ class: 'l3-nav__menu-title' });
-    if (index === 0) {
-      breadCrumbTitleElem.innerHTML = `<span class="title-option">
+    const breadCrumbTitleElemDesktop = div({ class: 'l3-nav__menu-title' });
+    breadCrumbTitleElemDesktop.innerHTML = `<span class="title-option">
     <a class="title-option__l3nav" data-static-label="${title}">
-              <span class="nav-icon Vlt-icon-phone"></span>
               <span>${title}</span>
             </a>
           </span>`;
+    breadCrumbTitleElemDesktop.addEventListener('click', toggleBreadCrumb);
+    breadCrumbDesktop.querySelector('.left-sec').appendChild(breadCrumbTitleElemDesktop);
+    breadCrumbMobile.querySelector('.l3-nav__mobile--closed .left-sec').appendChild(a({ class: 'title-item', innerHTML: title }));
 
-      breadCrumbTitleElem.addEventListener('click', toggleBreadCrumb);
-      breadCrumb.querySelector('.left-sec').appendChild(breadCrumbTitleElem);
-    } else {
-      const separator = span({ class: 'separator' });
-      separator.innerHTML = '/';
-      breadCrumb.querySelector('.left-sec .l3-nav__menu-title:last-child').appendChild(separator);
-      breadCrumbTitleElem.innerHTML = `<span class="title-option">
-                                <a class="title-option__l3nav" data-static-label="${title}">
-                                    <span>${title}</span>
-                                </a>
-                            </span>`;
+    if (index === 0) {
+      // Add an icon for decoration in the desktop title
+      const iconSpan = span({ class: 'nav-icon Vlt-icon-phone' });
+      breadCrumbTitleElemDesktop.querySelector('a').prepend(iconSpan);
 
-      breadCrumbTitleElem.addEventListener('click', toggleBreadCrumb);
-      breadCrumb.querySelector('.left-sec').appendChild(breadCrumbTitleElem);
+      // Add the first link for the open mobile breadcrumb
+      breadCrumbMobile.querySelector('.l3-nav__mobile--open .left-sec').appendChild(a({ class: 'title-item', innerHTML: title }));
     }
+
+    // If there is more than one breadcrumb title, and we aren't on the last
+    if (index !== data.titles.length - 1 && data.titles.length > 1) {
+      // Add a separator for the desktop breadcrumb
+      breadCrumbDesktop.querySelector('.left-sec .l3-nav__menu-title:last-child').appendChild(span({ class: 'separator', innerHTML: '/' }));
+      breadCrumbMobile.querySelector('.l3-nav__mobile--closed .left-sec').appendChild(span({ class: 'separator', innerHTML: '/' }));
+    }
+
+    // If this is the last title in the breadcrumb
     if (index === data.titles.length - 1) {
+      // Add a trailing chevron decoration
       const chevron = span({ class: 'Vlt-icon-chevron arrow-icn' });
-      breadCrumb.querySelector('.l3-nav__menu-title:last-child .title-option__l3nav').classList.add('boldbreadCrumbTitle');
-      breadCrumb.querySelector('.l3-nav__menu-title:last-child').appendChild(chevron);
+      breadCrumbDesktop.querySelector('.l3-nav__menu-title:last-child .title-option__l3nav').classList.add('boldbreadCrumbTitle');
+      breadCrumbDesktop.querySelector('.l3-nav__menu-title:last-child').appendChild(chevron);
     }
   });
 
-  const sectionBreadCrumb = div({ class: 'menu-option-sublist l3-nav__menu-options' },
+  // ToDo: Split this off into a separate function to build the section element
+  const sectionBreadCrumbDesktop = div({ class: 'menu-option-sublist l3-nav__menu-options' },
     div({ class: 'container sublist-container' },
       div({ class: 'list l3-nav__menu-options--list first' },
         ul())));
 
-  // const sectionBreadCrumb = div({ class: 'list l3-nav__menu-options--list first' }, ul());
-  // ToDo: This width needs to be based on a calculation of the width of of the title
-  sectionBreadCrumb.querySelector('.list.l3-nav__menu-options--list.first').style.width = data.links[0].width;
-  for (const root of data.links) {
-    const breadCrumbLink = a({ class: 'l3-nav__submenu', href: root.url });
-    breadCrumbLink.innerHTML = root.label;
+  sectionBreadCrumbDesktop.querySelector('.list.l3-nav__menu-options--list.first').style.width = data.links[0].width;
+
+  const sectionBreadCrumbMobile = ul();
+
+  data.links.forEach((root) => {
+    const breadCrumbLink = a({ class: 'l3-nav__submenu', href: root.url, innerHTML: root.label });
     if (root.url === `/${pathArray.join('/')}`) {
       breadCrumbLink.classList.add('bold');
     }
-    sectionBreadCrumb.querySelector('ul').appendChild(li(breadCrumbLink));
-  }
-  breadCrumb.querySelector('.left-sec').appendChild(sectionBreadCrumb);
+    sectionBreadCrumbDesktop.querySelector('ul').appendChild(li(breadCrumbLink));
+    sectionBreadCrumbMobile.appendChild(li(span(breadCrumbLink)));
+  });
+
+  breadCrumbDesktop.querySelector('.left-sec').appendChild(sectionBreadCrumbDesktop);
+  breadCrumbMobile.querySelector('.menu-sub-list').appendChild(sectionBreadCrumbMobile);
 
   // If the page is a subsection based on its section metadata
   // need to load the relevant subsection breadcrumb data
   if (inSubSection) {
-    const subSectionBreadCrumb = div({ class: 'list l3-nav__menu-options--list' }, ul());
+    breadCrumbMobile.querySelector('.menu-sub-list').appendChild(a({ class: 'title-item', innerHTML: data.titles[1] }));
     const subSection = `/${pathArray[0]}/${pathArray[1]}/`;
+    const subSectionBreadCrumbDesktop = div({ class: 'list l3-nav__menu-options--list' }, ul());
+    const subSectionBreadCrumbMobile = ul();
 
     // Find the index in the linksData data of the root page we are currently on given the section metadata
     const index = data.links.indexOf(data.links.find((o) => o.url === subSection));
 
-    for (const child of data.links[index].children) {
-      const breadCrumbLink = a({ class: 'l3-nav__submenu', href: child.url });
-      breadCrumbLink.innerHTML = child.label;
+    data.links[index].children.forEach((child) => {
+      const breadCrumbLink = a({ class: 'l3-nav__submenu', href: child.url, innerHTML: child.label });
       if (child.url === `/${pathArray.join('/')}/`) {
         breadCrumbLink.classList.add('bold');
       }
-      subSectionBreadCrumb.style.width = data.links[index].width;
-      subSectionBreadCrumb.querySelector('ul').appendChild(li(breadCrumbLink));
-    }
-    breadCrumb.querySelector('.sublist-container').appendChild(subSectionBreadCrumb);
+      subSectionBreadCrumbDesktop.style.width = data.links[index].width;
+      subSectionBreadCrumbDesktop.querySelector('ul').appendChild(li(breadCrumbLink));
+      subSectionBreadCrumbMobile.appendChild(li(span(breadCrumbLink)));
+    });
+
+    breadCrumbDesktop.querySelector('.sublist-container').appendChild(subSectionBreadCrumbDesktop);
+    breadCrumbMobile.querySelector('.menu-sub-list').appendChild(subSectionBreadCrumbMobile);
+  }
+  if (data.titles[2] != '') {
+    breadCrumbMobile.querySelector('.menu-sub-list').appendChild(a({ class: 'title-item', innerHTML: data.titles[2] }));
   }
 }
+
 /* ------------------------------ Main function invoked at load ------------------------------- */
 
 /**
@@ -680,7 +812,8 @@ export default async function decorate(block) {
     const headerBackdrop = div({ id: 'backdrop', class: 'header backdrop' });
     block.append(headerBackdrop);
     block.append(navWrapper);
-    block.append(buildBreadCrumb());
+    block.append(buildBreadCrumbMobile());
+    block.append(buildBreadCrumbDesktop());
   }
 
   let sectionPathFull = window.location.pathname;

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -135,22 +135,6 @@ function buildHierarchy(flat) {
   return structuredLinks;
 }
 
-/**
- * A utility function to create divs with specified ID and classes
- * @param {string} id The id to associate with the created div element
- * @param {[string]} classes an array of strings indicating the classes to add to the div element
- * @returns {HTMLDivElement}
- */
-// ToDo: Deprecate this infavor of the new div implementation from Wegmuir
-function createDiv(id, classes) {
-  const div = document.createElement('div');
-  div.id = id;
-  classes.forEach((className) => {
-    div.classList.add(className);
-  });
-  return div;
-}
-
 function focusNavSection() {
   document.activeElement.addEventListener('keydown', openOnKeydown);
 }
@@ -338,7 +322,7 @@ function decorateSubSections(navSection, sectionIndex) {
   navSection.classList.add('nav-drop');
 
   // Create a div to wrap the items in the drop-down menu to handle displaying as a popout
-  const subMenuWrapper = createDiv(`sub-menu-${safeSectionName}`, ['sub-menu']);
+  const subMenuWrapper = div({ id: `sub-menu-${safeSectionName}`, class: 'sub-menu' });
 
   // Add a span for the close button in the menu
   const closeButton = document.createElement('span');
@@ -616,7 +600,7 @@ function populateBreadCrumb(data, pathArray) {
  * @returns {HTMLDivElement} Div containing the return to main menu button with event listeners
  */function buildBackButton() {
   // Back button for mobile
-  const backButton = createDiv('back-button', ['nav-back-button']);
+  const backButton = div({ id: 'back-button', class: 'nav-back-button' });
   backButton.innerHTML = `<button type="button" aria-controls="nav" aria-label="back to site navigation menu">
         Main Menu
       </button>`;
@@ -643,7 +627,7 @@ export default async function decorate(block) {
     nav.classList.add('nav-big');
 
     // Add a wrapper div to contain the full nav (logo and sections)
-    nav.appendChild(createDiv('header-navigation', ['header-navigation']));
+    nav.appendChild(div({ id: 'header-navigation', class: ['header-navigation'] }));
     nav.firstElementChild.innerHTML = html;
 
     // Tag the sections from the returned markdown based on their order with class categorization
@@ -686,14 +670,14 @@ export default async function decorate(block) {
     // Make sure that on initial display the nav is not flagged as open
     nav.setAttribute('aria-expanded', 'false');
 
-    const navWrapper = createDiv('nav-wrapper', ['nav-wrapper']);
+    const navWrapper = div({ id: 'nav-wrapper', class: 'nav-wrapper' });
 
     // Add the logo element before the nav elements which will stack vertically
     navWrapper.append(buildLogo());
     navWrapper.append(nav);
 
     // div element to be used for the mobile pop over menu
-    const headerBackdrop = createDiv('backdrop', ['header', 'backdrop']);
+    const headerBackdrop = div({ id: 'backdrop', class: 'header backdrop' });
     block.append(headerBackdrop);
     block.append(navWrapper);
     block.append(buildBreadCrumb());

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -477,7 +477,7 @@ function buildBreadCrumb() {
           </span>
           <span class="Vlt-icon-chevron arrow-icn"></span>
         </div>
-        <div class="menu-option-sublist l3-nav__menu-options">
+        <div class="menu-option-sublist l3-nav__menu-options active">
           <div class="container sublist-container"></div>
         </div>
       </div>
@@ -514,76 +514,6 @@ function populateBreadCrumb(container, links) {
   container.appendChild(parentBreadCrumb);
 
   // TODO: Need to add logic here that determines whether we are in one of the sections and if so create a secondary div and append it
-  //
-  // <div className="list l3-nav__menu-options--list first" style="width: 225px;">
-  //   <ul>
-  //     <li>
-  //       <a className="l3-nav__submenu active"
-  //          href="/unified-communications/?icmp=l3breadrumb|l3nav_unifiedcommunications_overview"
-  //          data-static-label="Overview" data-di-id="l3breadrumb|l3nav_unifiedcommunications_overview"
-  //          data-external="false">
-  //         Overview
-  //       </a>
-  //     </li>
-  //     <li>
-  //       <a className="l3-nav__submenu "
-  //          href="/unified-communications/platform/?icmp=l3breadrumb|l3nav_unifiedcommunications_platform"
-  //          data-static-label="Platform" data-di-id="l3breadrumb|l3nav_unifiedcommunications_platform"
-  //          data-external="false">
-  //         Platform
-  //       </a>
-  //     </li>
-  //     <li>
-  //       <a className="l3-nav__submenu "
-  //          href="/unified-communications/features/?icmp=l3breadrumb|l3nav_unifiedcommunications_features"
-  //          data-static-label="Features" data-di-id="l3breadrumb|l3nav_unifiedcommunications_features"
-  //          data-external="false">
-  //         Features
-  //       </a>
-  //     </li>
-  //     <li>
-  //       <a className="l3-nav__submenu "
-  //          href="/unified-communications/call-center/?icmp=l3breadrumb|l3nav_unifiedcommunications_callcenter"
-  //          data-static-label="Call Center" data-di-id="l3breadrumb|l3nav_unifiedcommunications_callcenter"
-  //          data-external="false">
-  //         Call Center
-  //       </a>
-  //     </li>
-  //     <li>
-  //       <a className="l3-nav__submenu "
-  //          href="/unified-communications/use-cases/?icmp=l3breadrumb|l3nav_unifiedcommunications_usecases"
-  //          data-static-label="Use Cases" data-di-id="l3breadrumb|l3nav_unifiedcommunications_usecases"
-  //          data-external="false">
-  //         Use Cases
-  //       </a>
-  //     </li>
-  //     <li>
-  //       <a className="l3-nav__submenu "
-  //          href="/unified-communications/integrations/?icmp=l3breadrumb|l3nav_unifiedcommunications_integrations"
-  //          data-static-label="Integrations" data-di-id="l3breadrumb|l3nav_unifiedcommunications_integrations"
-  //          data-external="false">
-  //         Integrations
-  //       </a>
-  //     </li>
-  //     <li>
-  //
-  //       <a className="l3-nav__submenu "
-  //          href="/unified-communications/global/?icmp=l3breadrumb|l3nav_unifiedcommunications_international"
-  //          data-static-label="International" data-di-id="l3breadrumb|l3nav_unifiedcommunications_international"
-  //          data-external="false">
-  //         International
-  //       </a>
-  //     </li>
-  //     <li>
-  //       <a className="l3-nav__submenu "
-  //          href="/unified-communications/pricing/?icmp=l3breadrumb|l3nav_unifiedcommunications_pricing"
-  //          data-static-label="Pricing" data-di-id="l3breadrumb|l3nav_unifiedcommunications_pricing"
-  //          data-external="false">
-  //         Pricing
-  //       </a>
-  //     </li>
-  //   </ul>
-  // </div>
 }
 /* ------------------------------ Main function invoked at load ------------------------------- */
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -91,6 +91,7 @@ export function i(...items) { return domEl('i', ...items); }
 export function img(...items) { return domEl('img', ...items); }
 export function span(...items) { return domEl('span', ...items); }
 export function button(...items) { return domEl('button', ...items); }
+export function hr(...items) { return domEl('hr', ...items); }
 
 /**
  * Builds hero block and prepends to main in a new section.

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -55,7 +55,7 @@ export function domEl(tag, ...items) {
 
     Object.entries(attributes).forEach(([key, value]) => {
       // Add additional properties here for things that fail to reflect through setAttributes
-      const directAttributes = ['innerHTML', 'innerText'];
+      const directAttributes = ['innerHTML'];
       if (directAttributes.includes(key)) {
         element[key] = value;
       } else if (!key.startsWith('on')) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -55,8 +55,7 @@ export function domEl(tag, ...items) {
 
     Object.entries(attributes).forEach(([key, value]) => {
       // Add additional properties here for things that fail to reflect through setAttributes
-      const directAttributes = ['innerHTML'];
-      if (directAttributes.includes(key)) {
+      if (['innerHTML'].includes(key)) {
         element[key] = value;
       } else if (!key.startsWith('on')) {
         element.setAttribute(key, Array.isArray(value) ? value.join(' ') : value);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -54,7 +54,11 @@ export function domEl(tag, ...items) {
     items = rest;
 
     Object.entries(attributes).forEach(([key, value]) => {
-      if (!key.startsWith('on')) {
+      // Add additional properties here for things that fail to reflect through setAttributes
+      const directAttributes = ['innerHTML', 'innerText'];
+      if (directAttributes.includes(key)) {
+        element[key] = value;
+      } else if (!key.startsWith('on')) {
         element.setAttribute(key, Array.isArray(value) ? value.join(' ') : value);
       } else {
         element.addEventListener(key.substring(2).toLowerCase(), value);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -123,7 +123,7 @@
   --button-font-size-m: 16px;
 
   /* nav height */
-  --nav-height: 11.4rem;
+  --nav-height: 12.5rem;
 
 }
 
@@ -174,8 +174,9 @@ header {
   height: var(--nav-height);
 }
 
+/* Offset main site content by the height of the nav plus the breadcrumb */
 main {
-  margin-top: var(--nav-height);
+  margin-top: calc(var(--nav-height) + 68px);
 }
 
 h1, h2, h3,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -356,6 +356,18 @@ main img {
   vertical-align: middle;
 }
 
+[class*=" Vlt-icon-"], [class^="Vlt-icon-"] {
+  font-family: var(--icon-font-family);
+  font-style: normal;
+  font-variant: normal;
+  font-weight: 400;
+  line-height: inherit;
+  speak: none;
+  text-transform: none;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
 main .section {
   padding: 64px 16px;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -126,6 +126,7 @@
 
   /* nav height */
   --nav-height: 12.5rem;
+  --mobile-nav-height: 11.1rem;
 
 }
 
@@ -179,7 +180,7 @@ body.appear {
 
 header {
   position: fixed;
-  height: var(--nav-height);
+  height: var(--mobile-nav-height);
 }
 
 /* Offset main site content by the height of the nav plus the breadcrumb */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -366,7 +366,7 @@ main img {
   vertical-align: middle;
 }
 
-[class*=" Vlt-icon-"], [class^="Vlt-icon-"] {
+[class*=" vlt-icon-"], [class^="vlt-icon-"] {
   font-family: var(--icon-font-family);
   font-style: normal;
   font-variant: normal;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -163,8 +163,6 @@ body {
   line-height: 1.6;
   color: var(--text-color);
   display: none;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
 }
 
 .white-gradient-down {
@@ -186,7 +184,7 @@ header {
 
 /* Offset main site content by the height of the header */
 main {
-  margin-top: calc(var(--mobile-nav-height));
+  margin-top: var(--mobile-nav-height);
 }
 
 h1, h2, h3,
@@ -375,8 +373,6 @@ main img {
   line-height: inherit;
   speak: none;
   text-transform: none;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
 }
 
 main .section {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -127,7 +127,8 @@
   /* nav height */
   --nav-height: 12.5rem;
   --mobile-nav-height: 11.1rem;
-
+  --bread-crumb-height: 6.3rem;
+  --mobile-bread-crumb-height: 5.2rem;
 }
 
 @media (min-width: 900px) {
@@ -183,9 +184,9 @@ header {
   height: var(--mobile-nav-height);
 }
 
-/* Offset main site content by the height of the nav plus the breadcrumb */
+/* Offset main site content by the height of the header */
 main {
-  margin-top: calc(var(--nav-height) + 68px);
+  margin-top: calc(var(--mobile-nav-height));
 }
 
 h1, h2, h3,
@@ -392,6 +393,13 @@ main .section {
   .section > div {
     max-width: 990pt;
     margin: auto;
+  }
+}
+
+@media (min-width: 992px) {
+  /* Offset main site content by the height of the nav plus the breadcrumb */
+  main {
+    margin-top: calc(var(--nav-height) + var(--bread-crumb-height));
   }
 }
 


### PR DESCRIPTION
Fix #5

Test URLs:
1st tier page:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/
- After: https://issue-5-subnav--vonage--hlxsites.hlx.page/unified-communications/
- Client: https://www.vonage.com/unified-communications/

2nd tier page:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/features
- After: https://issue-5-subnav--vonage--hlxsites.hlx.page/unified-communications/features
- Client: https://www.vonage.com/unified-communications/features/

3rd tier page:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/features/desktop
- After: https://issue-5-subnav--vonage--hlxsites.hlx.page/unified-communications/features/desktop
- Client: https://www.vonage.com/unified-communications/features/desktop/

Known issues:

- [x] Need to add an outside menu area click handler (for both header and breadcrumb) to trigger a close of the menu #77
- [x] Need to figure out why the breadcrumb fadein animation isn't triggering #78
- [x] Need to add a media directive to cause the "buy Now" button to disappear at < 992 px #79
- [x] Font styling (in particular font-weight) does not match to the client site, presume that's related to #33 

Notes: 
Breadcrumb path data is populated via the section named (so for our case unified-communications) sheet in the sub-nav folder of our drive [here](https://docs.google.com/spreadsheets/d/1vOhcDPfa2Aqg47YAoB2SBt8ppTbvDTeNL4B5VhYnAhs/edit#gid=0)
Each row of the sheet represents a text element of the breadcrumb
The rows are either parents or children, where parents are always displayed in the first section of the breadcrumb and children are only shown if in the parent of the child's page. 
Each row has the following properties:

- label - The text to display for this row of the breadcrumb or if a parent in the breadcrumb title bar
- url - The url to open on click of the breadcrumb item
- parent - The **url** of the parent element, this designates the row as a child, if no parent url is specified the row is a parent 
- width - Only applicable to parent rows, this controls how wide the child row column should be based on the width of the parent label

The flat data is parsed on load into a hierarchical set, and I did not choose to implement logic to handle children coming before parents, so a logical structure needs to be maintained where parents come before their children. 

This data is used in the page via parsing the `window.location.pathname` and matching that against the url values found in the sheet data.  This lets us know what level of page we are on (how many folders down) and what are the correct breadcrumb elements to display for navigating within that section. 