### PR TITLE
Addressing over padding in section layout

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -380,12 +380,12 @@ main img {
 }
 
 main .section {
-  padding: 64px 16px;
+  padding: 0 16px 64px;
 }
 
 @media (min-width: 600px) {
   main .section {
-    padding: 9.6rem 3.2rem;
+    padding: 0 3.2rem 9.6rem;
   }
 }
 


### PR DESCRIPTION
Don't need it on the top and bottom of each section element

Fix #65

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/
- After: https://issue-65-address-padding-between-sections--vonage--hlxsites.hlx.page/unified-communications/
