### PR TITLE
Fixing background color not extending to full block height

### DIFF
--- a/blocks/pricing-matrix/pricing-matrix.css
+++ b/blocks/pricing-matrix/pricing-matrix.css
@@ -1,5 +1,8 @@
 .section.pricing-matrix-container {
     background-color: #eeeffc;
+
+    /* Bit of a hack fix to https://github.com/hlxsites/Vonage/issues/107 */
+    border-top: 1px solid #eeeffc;
 }
 
 .pricing-matrix .quantity-selector .quantity-count {


### PR DESCRIPTION
Fix #107 - Bit of a hack, but don't think it's worth spending the time time digging into the underlying why of this behavior if this style adjustment fixes the issue.

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/pricing
- After: https://issues-107-pricing-matrix-hf--vonage--hlxsites.hlx.page/unified-communications/pricing
