### PR TITLE
remove padding from slim-promo

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -174,12 +174,14 @@ div.columns.plans > div > div > p.button-container a.button.secondary {
   padding: 1.6rem;
 }
 
-
-/** for FireFox (lack of) support for :has selector **/
 .black-bg {
   background-color: #000;
   padding-top: 2rem;
   padding-bottom: 2rem;
+}
+
+div.section.black-bg.columns-container {
+  padding-bottom: 0;
 }
 
 div.columns.border-bottom-gray {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/
- After: https://slim-promo-padding--vonage--hlxsites.hlx.live/unified-communications/
