### PR TITLE
Default-content-wrapper font styling incorrect in pricing page

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -423,7 +423,8 @@ div.default-content-wrapper > h2 + p {
   text-align: center !important;
 }
 
-div.section.pricing-matrix > div.default-content-wrapper > p {
+div.section.pricing-matrix > div.default-content-wrapper > p,
+div.section.background-pricing > div.default-content-wrapper > p {
   font-size: var(--body-font-size-xxs);
   letter-spacing: 0.025rem;
   color: var(--end-note-text-color);
@@ -431,12 +432,14 @@ div.section.pricing-matrix > div.default-content-wrapper > p {
   text-align: left;
 }
 
-div.section.pricing-matrix > div.default-content-wrapper > p > strong {
+div.section.pricing-matrix > div.default-content-wrapper > p > strong,
+div.section.background-pricing > div.default-content-wrapper > p > strong {
   font-size: var(--body-font-size-s);
   font-weight: 700;
 }
 
-div.section.pricing-matrix > div.default-content-wrapper a {
+div.section.pricing-matrix > div.default-content-wrapper a,
+div.section.background-pricing > div.default-content-wrapper a {
   text-decoration: underline;
   color: #000;
 }


### PR DESCRIPTION
Hotfix for the default content wrapper styling on the pricing page that was mentioned in the sync call.

Turns out the styling was section dependent and the pricing page had a different section named.

Fix #N/A

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/pricing/
- After: https://hf-default-content-styling--vonage--hlxsites.hlx.page/unified-communications/pricing/
