### PR TITLE
Fixing default text style after phone service content fragment

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -440,3 +440,27 @@ div.section.pricing-matrix > div.default-content-wrapper a {
   text-decoration: underline;
   color: #000;
 }
+
+div.section.business-phone-service > div.default-content-wrapper {
+  color: #5f6169;
+  font-family: var(--body-font-family);
+  font-size: 1.2rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.6rem;
+  text-align: left;
+  margin-top: -64px;
+}
+
+div.section.business-phone-service > div.default-content-wrapper p::before {
+  content: "*";
+  position: relative;
+  top: -0.2rem;
+}
+
+@media (min-width: 1200px) {
+  div.section.business-phone-service > div.default-content-wrapper {
+    letter-spacing: .025rem;
+  }
+}
+


### PR DESCRIPTION
For the little disclaimer text that comes in below this 2-col fragment.  Note that I think there needs to be some adjustment to the padding in the 2-col fragment block (think we are double dipping on padding and not filing the available page space, will tackle that as a fix next. 

Fix #N/A

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/pricing/
- After: https://hf-fragment-disclaimer-text--vonage--hlxsites.hlx.page/unified-communications/pricing/
