### PR TITLE
Hf addressing column fragment padding and wrap

### DIFF
--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -4,7 +4,7 @@ div.fragment.two-col {
     box-sizing: inherit;
     position: relative;
     width: 100%;
-    padding: 64px 20px;
+    padding: 64px 0;
     display: flex;
     flex-direction: column-reverse;
 }
@@ -12,7 +12,7 @@ div.fragment.two-col {
 div.fragment.two-col > div {
     position: relative;
     width: 100%;
-    padding: 0 20px;
+    padding: 0;
 }
 
 div.fragment.two-col > .leftcolumn {

--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -26,6 +26,11 @@ div.fragment.two-col > .rightcolumn {
     max-width: 41.6667%;
 }
 
+.fragment.two-col .columns > div {
+  display: flex;
+  flex-flow: row wrap;
+}
+
 div.fragment.two-col a:any-link {
     color: #000;
     transition: transform .2s;
@@ -132,5 +137,10 @@ div.fragment.lead-gen > div.section {
   div.fragment.two-col {
     display: flex;
     flex-direction: initial;
+  }
+
+  div.fragment .columns-img-col {
+    flex: 0 0 41.667%;
+    max-width: 41.667%;
   }
 }


### PR DESCRIPTION
Fixing up the margins / padding for the 2-column fragment, and introducing wrap behavior at smaller resolutions. 

Fix N/A

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/pricing/
- After: https://hf-addressing-column-fragment-padding--vonage--hlxsites.hlx.page/unified-communications/pricing/
