### PR TITLE
Removing background-color on case study column

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -511,7 +511,6 @@ div.columns.lead-gen>div>div:last-child>p:last-child>a:last-child::before {
 
 /* Container padding and background */
 div.case-study.columns-container {
-  background-color: #eeeffc;
   padding: 0 3.2rem;
 }
 


### PR DESCRIPTION
Color shouldn't have been defined in the block, instead handled in the section. 

Fix #N/A

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/
- After: https://hf-case-study-bg-color--vonage--hlxsites.hlx.page/unified-communications/
