### PR TITLE
Virtualization column does not render correctly

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -664,13 +664,13 @@ div.columns.details-columns > div > div.columns-other-col > h2 {
   font-size: var(--heading-font-size-m);
   font-weight: 500;
   letter-spacing: -0.15rem;
-} 
+}
 
 div.columns.details-columns > div > div.columns-other-col > p {
   font-size: var(--body-font-size-xs);
   font-weight: 400;
   letter-spacing: -0.02rem;
-} 
+}
 
 div.columns.details-columns > div > div.columns-other-col > p.button-container {
   margin-top: 5rem;
@@ -687,7 +687,7 @@ div.columns.details-columns > div > div.columns-other-col > p.button-container >
   text-decoration: underline;
   scale: 1.0;
   transition: transform 0.2s ease;
-} 
+}
 
 div.columns.details-columns > div > div.columns-other-col > p.button-container > a:hover {
   transform: scale(1.02);
@@ -702,19 +702,25 @@ div.columns.details-columns > div > div.columns-other-col > ul {
   color:  var(--text-color);
   text-decoration-color: var(--text-color);
   text-decoration-line: none;
-} 
+}
 
 div.columns.details-columns > div > div.columns-other-col > ul a {
   font-size: 1.4rem;
   color: var(--text-color);
   text-decoration: none;
-} 
+}
 
 div.columns.details-columns > div > div.columns-other-col > ul a:any-link {
   transition: transform .2s;
 }
 
 div.columns.details-columns > div > div.columns-other-col > ul a:hover {
+  text-decoration: underline;
+}
+
+div.columns.details-columns p.detail-paragraph a:any-link {
+  display: inline;
+  color: var(--text-color);
   text-decoration: underline;
 }
 
@@ -797,13 +803,13 @@ div.columns.details-columns > div > div.columns-other-col > ul a:hover {
   div.columns.block.details-columns > div > div.columns-img-col {
     flex: 1 0 0;
   }
-  
+
   div.columns.block.details-columns > div > div.columns-other-col {
     flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
-  
+
 }
 
 @media (min-width: 992px) {

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -42,7 +42,8 @@ function movePictureIntoAnchor(col) {
   }
   const aElem = col.querySelector('a[href]');
   if (aElem != null) {
-    const img = col.querySelector('div > picture > img');
+    aElem.classList.remove('button', 'primary');
+    const img = col.querySelector('img');
     if (img != null) {
       aElem.innerHTML = '';
       aElem.append(img.parentNode);
@@ -107,8 +108,15 @@ export default function decorate(block) {
       if (col.querySelector('picture')) {
         // column contains a picture
         col.classList.add('columns-img-col');
+        // If there is a link specified after the image wrap the image in an a referencing the link
+        movePictureIntoAnchor(col);
       } else {
         col.classList.add('columns-other-col');
+        col.querySelectorAll('p').forEach((pElem) => {
+          if (!pElem.classList.contains('button-container')) {
+            pElem.classList.add('detail-paragraph');
+          }
+        });
       }
 
       if (block.classList.contains('case-study') && col.classList.contains('columns-other-col')) {
@@ -174,9 +182,6 @@ export default function decorate(block) {
   if (block.classList.contains('details-columns')) {
     [...block.children].forEach((row) => {
       [...row.children].forEach((col) => {
-        if (col.classList.contains('columns-img-col')) {
-          movePictureIntoAnchor(col);
-        }
         if (col.classList.contains('columns-other-col')) {
           buildSingleList(col);
 

--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -43,6 +43,10 @@ div.fragment.two-col .columns-img-col a {
   width: 100%;
 }
 
+div.fragment.two-col li > a:hover, div.fragment.two-col li > strong > a:hover {
+  text-decoration: underline;
+}
+
 div.fragment.two-col p.detail-paragraph a:any-link {
   display: inline;
   text-decoration: underline;
@@ -71,10 +75,6 @@ div.fragment.two-col a.button.primary::after {
   display: block;
   height: .2rem;
   width: 100%;
-}
-
-div.fragment.two-col li > a:hover, div.fragment.two-col li > strong > a:hover {
-    text-decoration: underline;
 }
 
 div.fragment.two-col .fragment-link {

--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -39,6 +39,15 @@ div.fragment.two-col a:any-link {
     display:inline-block;
 }
 
+div.fragment.two-col .columns-img-col a {
+  width: 100%;
+}
+
+div.fragment.two-col p.detail-paragraph a:any-link {
+  display: inline;
+  text-decoration: underline;
+}
+
 div.fragment.two-col a.button.primary {
   border-radius: unset;
   background-color: transparent;


### PR DESCRIPTION
Fix #123 

Added support for columns block to wrap the image column in an <a> by including a link after the image in the markdown. 
Fixed styling for inline links in the detail text of the column block (both those loaded via fragments and not)

Confirmed that the detail-columns block variant introduced by @jimaldous was not affected via these changes through his own drafts page:

https://main--vonage--hlxsites.hlx.page/drafts/columns-details-columns
https://issue-123-2-col-fragment--vonage--hlxsites.hlx.page/drafts/columns-details-columns

Other than the correction on link text color and decoration.

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/platform
- After: https://issue-123-2-col-fragment--vonage--hlxsites.hlx.page/unified-communications/
