### PR TITLE
Card images are too small 

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -103,6 +103,11 @@
   margin: 3rem auto;
 }
 
+.cards-container.icon-panel .large-icon .cards-card-image {
+  width: 75pt;
+  height: 75pt;
+}
+
 .cards-container.icon-panel .cards-card-body {
   letter-spacing: -0.02rem;
   margin-left: auto;


### PR DESCRIPTION
Fix #138 

Added a new variant to the cards block to allow specifying for large icons via Cards(large-icon)

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/insurance
- After: https://issue-138-small-card-images--vonage--hlxsites.hlx.page/unified-communications/insurance
