### PR TITLE
Styling for the world office location column variant

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -412,6 +412,179 @@ div.columns.lead-gen>div>div:last-child>p:last-child>a:last-child::before {
   margin-left: 30px;
 }
 
+.section.headerlists .columns.block {
+  max-width: unset;
+}
+
+div.section.headerlists{
+  padding: 0;
+  margin-top: -2rem;
+}
+
+div.section.headerlists div.columns.block > div {
+  position: relative;
+  z-index: 100;
+  flex-wrap: wrap;
+  gap:0;
+  max-width: 45pc;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+div.section.headerlists div.columns-other-col {
+  flex: 0 0 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  background-color: #eeeffc;
+}
+
+div.section.headerlists div.default-content-wrapper{
+  max-width: unset;
+}
+
+div.section.headerlists div.default-content-wrapper:first-child {
+  background-color: #000;
+  position: relative;
+  padding-bottom: 7rem;
+}
+
+div.section.headerlists div.default-content-wrapper:first-child p::after {
+  background: -webkit-gradient(linear,left top,right top,from(#881fff),to(#7fc8f5));
+  background: linear-gradient(90deg,#881fff 0,#7fc8f5);
+  bottom: 0;
+  content: "";
+  height: 1rem;
+  left: 0;
+  position: absolute;
+  width: 100%;
+  z-index: 0;
+}
+
+div.section.headerlists div.default-content-wrapper:first-child > p {
+  font-family: var(--body-font-family);
+  font-size: 1.7rem;
+  font-weight: 400;
+  letter-spacing: -.025rem;
+  line-height: 2.5rem;
+  color: #fff;
+  margin-left: 16.667%;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+div.section.headerlists div.columns-other-col ul {
+  font-family: var(--body-font-family);
+  font-size: 1.4rem;
+  font-weight: 400;
+  letter-spacing: -.02rem;
+  line-height: 2rem;
+  list-style-type: disc;
+  padding-left: 4rem;
+  background-color: #eeeffc;
+}
+
+div.section.headerlists div.columns.block {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+div.section.headerlists div.columns-other-col li {
+  margin-top: 1.5rem;
+  padding-left:0.7rem;
+}
+
+@media (min-width: 768px) {
+  div.section.headerlists div.default-content-wrapper:first-child > p {
+    max-width: 50%;
+    margin-left: 50%;
+    padding-left: 2rem;
+    padding-right: 2rem;
+    z-index: 0;
+  }
+
+  div.section.headerlists div.columns-other-col {
+    background-color: unset;
+    flex: 0 0 50%;
+    max-width: 50%;
+    box-sizing: border-box;
+  }
+
+  div.section.headerlists div.columns-other-col ul {
+  margin: 2rem;
+    padding:3rem;
+  }
+
+  div.section.headerlists div.default-content-wrapper:first-child {
+    padding-bottom: 20rem;
+  }
+
+  div.section.headerlists div.columns.block {
+    margin-top: -15rem;
+  }
+}
+
+  @media (min-width: 992px) {
+    div.section.headerlists div.columns-other-col {
+      flex: 0 0 50%;
+      max-width: 50%;
+    }
+
+    div.section.headerlists div.columns.block > div {
+      flex-wrap: nowrap;
+      max-width: 990pt;
+      margin-top: -20rem;
+    }
+
+    div.section.headerlists div.default-content-wrapper:first-child > p {
+      max-width: 50%;
+      margin-left: 50%;
+      padding-left: 2rem;
+      padding-right: 2rem;
+      margin-right: calc((100vw - 990pt) / 2);
+      z-index: 0;
+    }
+
+
+    div.section.headerlists div.columns-other-col ul {
+      font-size: 2.1rem;
+      font-weight: 400;
+      letter-spacing: -.025rem;
+      line-height: 2.4rem;
+    }
+
+    div.section.headerlists div.columns-other-col li {
+      margin-top: 3rem;
+      padding-left: 0.7rem;
+    }
+  }
+
+  div.section.headerlists div:nth-child(3) >p {
+    font-family: var(--body-font-family);
+    font-size: 1.2rem;
+    font-weight: 400;
+    letter-spacing: .025rem;
+    line-height: 1.6rem;
+    border-top: 0.1rem solid #c1c3cd;
+    padding-top: 1.5rem;
+    color: #5f6169;
+    text-align: left;
+  }
+
+  div.section.headerlists div:nth-child(3) {
+    padding:5rem 2rem;
+    box-sizing: border-box;
+    max-width: 990pt;
+  }
+
+@media(min-width: 1200px) {
+  div.section.headerlists div:nth-child(3) >p {
+    font-size: 1.2rem;
+    font-weight: 400;
+    letter-spacing: .025rem;
+    line-height: 1.6rem;
+  }
+}
+
 @media (min-width: 576px) {
   div.columns.block {
     max-width: 540px;
@@ -654,12 +827,6 @@ div.columns.details-columns > div {
   flex-wrap: wrap;
 }
 
-/* div.columns.details-columns > div > div.columns-img-col {
-  flex: 0 0 100%;
-  max-width: 100%;
-  width: 100%;
-} */
-
 div.columns.details-columns > div > div.columns-other-col {
   flex: 0 0 100%;
   max-width: 100%;
@@ -703,7 +870,7 @@ div.columns.details-columns > div > div.columns-other-col > ul {
   column-count: 2;
   column-gap: 4rem;
   font-size: 1.4rem;
-  font-weight: 400rem;
+  font-weight: 400;
   letter-spacing: .025rem;
   color:  var(--text-color);
   text-decoration-color: var(--text-color);
@@ -903,7 +1070,6 @@ span.view-offer {
   border-radius: 1.5rem;
   font-size: 14px;
   text-align: center;
-  line-break: none;
   font-weight: 400;
   width: 8rem;
   opacity: 1;

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -203,13 +203,16 @@ export default function decorate(block) {
     const offerTitle = block.querySelector('div.columns-other-col h2');
     const offerDetails = block.querySelector('div.columns-other-col p');
 
-    offerTitle.remove();
-    offerDetails.remove();
+    if (offerTitle) {
+      offerTitle.remove();
+      block.querySelector('.columns-other-col').appendChild(span({ class: 'titleWrapper' }, offerTitle));
+    }
 
-    block.querySelector('.columns-other-col').appendChild(span({ class: 'titleWrapper' }, offerTitle));
-    block.querySelector('.columns-other-col').appendChild(offerControls);
-    block.querySelector('.columns-other-col').appendChild(span({ class: 'detailWrapper' }, offerDetails));
-
-    addSlimPromoClickHandlers(block);
+    if (offerDetails) {
+      offerDetails.remove();
+      block.querySelector('.columns-other-col').appendChild(offerControls);
+      block.querySelector('.columns-other-col').appendChild(span({ class: 'detailWrapper' }, offerDetails));
+      addSlimPromoClickHandlers(block);
+    }
   }
 }


### PR DESCRIPTION
Handling the world office location (which could justifiably have been it's own block) but running it through the column block with some section based styling.

Fix #135

Draft available here: https://issue-135-world-office-locations--vonage--hlxsites.hlx.page/drafts/dgranber/columns-headerlist

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/global/world-office-locations
- After: https://issue-135-world-office-locations--vonage--hlxsites.hlx.page/unified-communications/global/world-office-locations
