### PR TITLE
Jump link block

### DIFF
--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -135,6 +135,46 @@ div.fragment.lead-gen > div.section {
   padding-bottom: 1rem;
 }
 
+div.fragment-container.two-col + .section {
+  max-width: 990pt;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+div.fragment-container.two-col + .section .default-content-wrapper {
+  max-width: 74.6rem;
+  margin-left: 0;
+}
+
+
+div.fragment-container.two-col + .section .default-content-wrapper > ol {
+  font-size: 1.2rem;
+  font-weight: 400;
+  letter-spacing: .025rem;
+  line-height: 1.6rem;
+  margin-top: 7rem;
+  counter-reset: item;
+  padding: 0;
+  list-style: none;
+}
+
+div.fragment-container.two-col + .section .default-content-wrapper > ol > li {
+  margin: 0 0 5px;
+  position: relative;
+  display: block;
+  padding: 0 0 0 1.5rem;
+}
+
+div.fragment-container.two-col + .section .default-content-wrapper > ol > li::before {
+  content: counter(item);
+  counter-increment: item;
+  position: absolute;
+  vertical-align: super;
+  font-size: x-small;
+  left: 0.6rem;
+  top: -0.6rem;
+}
+
 @media (min-width: 768px) {
   div.fragment.two-col ul {
     column-count: 2;

--- a/blocks/jump-links/jump-links.css
+++ b/blocks/jump-links/jump-links.css
@@ -1,0 +1,338 @@
+/* stylelint-disable no-descending-specificity */
+
+div.jump-links .row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -20px;
+  margin-left: -20px;
+}
+
+div.jump-links .column {
+  flex: 0 0 100%;
+  max-width: 100%;
+  position: relative;
+  box-sizing: border-box;
+}
+
+  .jump-links .container {
+    width: 100%;
+    padding-right: 20px;
+    padding-left: 20px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+.jump-links {
+  margin-bottom: 6rem;
+  margin-top: 2rem;
+}
+
+.jump-links-spacer {
+  background: linear-gradient(20deg,#881fff 40%,#827ef9);
+  display: none;
+  height: 9rem;
+}
+
+.jump-links-jump-link {
+  border-bottom: .1rem solid #dcdde6;
+  padding: 3rem 0;
+  position: relative;
+  transition: margin .25s ease;
+}
+
+
+.jump-links .vlt-icon-arrow-link,.jump-links-title {
+  font-family: var(--body-font-family);
+  font-size: 1.7rem;
+  letter-spacing: -.025rem;
+  line-height: 2.5rem;
+}
+
+@media (min-width: 768px) {
+  .jump-links-jump-link {
+    border-bottom: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links-spacer {
+    display: block;
+  }
+}
+
+.jump-links-jump-link:hover .vlt-icon-arrow-link {
+  bottom: -1rem;
+}
+
+@media (hover: none) {
+  .jump-links-jump-link:hover .vlt-icon-arrow-link {
+    bottom:.3rem;
+  }
+}
+
+.jump-links-heading {
+  padding-right: 18%;
+  pointer-events: none;
+  position: relative;
+}
+
+.jump-links-icon {
+  display: none;
+  height: 3rem;
+  width: 3rem;
+}
+
+.jump-links-label {
+  font-family: var(--body-font-family);
+  font-size: 1.2rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.6rem;
+  display: block;
+  margin-top: 1rem;
+  padding-right: 18%;
+  pointer-events: none;
+  position: relative;
+}
+
+.jump-links-title {
+  font-weight: 700!important;
+  overflow-wrap: break-word;
+}
+
+.jump-links .vlt-icon-arrow-link {
+  font-weight: 400;
+  bottom: 0;
+  position: absolute;
+  right: 0;
+  transform: rotate(90deg);
+  transition: bottom .25s ease;
+}
+
+.jump-links-link {
+  background-color: #fff;
+  border-radius: 2rem;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.vlt-icon-arrow-link::before {
+  content: var(--vlt-right-arrow);
+  font-family: var(--icon-font-family);
+}
+
+@media (min-width: 768px) {
+  .jump-links .container {
+    margin-top:-9rem;
+  }
+}
+
+@media (min-width: 576px) {
+  .jump-links .container {
+    max-width: 540px;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links .container {
+    max-width: 45pc;
+  }
+}
+
+@media (min-width: 992px) {
+  .jump-links .container {
+    max-width: 990pt;
+  }
+}
+
+
+@media (min-width: 1200px) {
+  .jump-links .container {
+    margin-top:-13rem;
+  }
+}
+
+@media (min-width: 576px) {
+  .jump-links .col-12:nth-child(n+3) {
+    margin-top:2rem;
+  }
+}
+
+@media (min-width: 992px) {
+  .jump-links .col-12:nth-child(n+3) {
+    margin-top:0;
+  }
+}
+
+@media (min-width: 768px) {
+  div.jump-links .column {
+    -webkit-box-flex: 0;
+    flex: 0 0 50%;
+    max-width: 50%;
+    position: relative;
+    width: 100%;
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .jump-links-spacer {
+    /* bit of a hack to get around the need for this spacer to extend full width of the viewport */
+    margin-left: -30rem;
+    margin-right: -30rem;
+    display:block;
+    position: relative;
+    top: -3rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .jump-links-spacer {
+    height:13rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links-jump-link {
+    padding-left:3rem;
+    padding-right: 3rem;
+    border-bottom: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links-jump-link:hover .jump-links-link {
+    margin:-1rem;
+  }
+}
+
+@media (min-width: 768px) and (hover:none) {
+  .jump-links-jump-link:hover .jump-links-link {
+    margin:0;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links-heading {
+    -webkit-box-align:center;
+    -ms-flex-align: center;
+    align-items: center;
+    display: block;
+  }
+}
+
+@media (min-width: 1200px) {
+  .jump-links-heading {
+    display:block;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links-icon {
+    display:block;
+    margin-bottom: 1.5rem;
+    margin-right: 0;
+  }
+}
+
+@media (min-width: 1200px) {
+  .jump-links-icon {
+    margin-bottom:3rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links-label {
+    font-family: var(--body-font-family);
+    font-size: 1.2rem;
+    font-weight: 400;
+    letter-spacing: 0;
+    line-height: 1.6rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .jump-links-label {
+    font-family: var(--body-font-family);
+    font-size: 1.2rem;
+    font-weight: 400;
+    letter-spacing: .025rem;
+    line-height: 1.6rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links-label {
+    padding-right:21.5%;
+  }
+}
+
+@media (min-width: 1200px) {
+  .jump-links-label {
+    margin-top:1.2rem;
+    padding-right: 22.7%;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links-title {
+    font-family: var(--body-font-family);
+    font-size: 1.7rem;
+    font-weight: 400;
+    letter-spacing: -.025rem;
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .jump-links-title {
+    font-family: var(--body-font-family);
+    font-size: 2.1rem;
+    font-weight: 400;
+    letter-spacing: -.025rem;
+    line-height: 2.4rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links-title {
+    line-height:normal;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links .vlt-icon-arrow-link {
+    font-family: var(--body-font-family);
+    font-size: 1.7rem;
+    font-weight: 400;
+    letter-spacing: -.025rem;
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .jump-links .vlt-icon-arrow-link {
+    font-family: var(--body-font-family);
+    font-size: 2.1rem;
+    font-weight: 400;
+    letter-spacing: -.025rem;
+    line-height: 2.4rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links .vlt-icon-arrow-link {
+    bottom:.3rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .jump-links-link {
+    border-bottom:none;
+    border-radius: 2rem;
+    box-shadow: 0 .2rem 1.4rem 0 hsl(0deg 0% 58.4% / 28%);
+    transition: margin .25s ease;
+  }
+}

--- a/blocks/jump-links/jump-links.css
+++ b/blocks/jump-links/jump-links.css
@@ -96,7 +96,7 @@
   transition: bottom .25s ease;
 }
 
-.jump-links-link {
+.jump-links-link:any-link {
   background-color: #fff;
   border-radius: 2rem;
   bottom: 0;
@@ -104,6 +104,11 @@
   position: absolute;
   right: 0;
   top: 0;
+  color:black;
+}
+
+.jump-links-link:any-link:hover {
+text-decoration:none;
 }
 
 .vlt-icon-arrow-link::before {

--- a/blocks/jump-links/jump-links.css
+++ b/blocks/jump-links/jump-links.css
@@ -1,27 +1,5 @@
 /* stylelint-disable no-descending-specificity */
 
-div.jump-links .row {
-  display: flex;
-  flex-wrap: wrap;
-  margin-right: -20px;
-  margin-left: -20px;
-}
-
-div.jump-links .column {
-  flex: 0 0 100%;
-  max-width: 100%;
-  position: relative;
-  box-sizing: border-box;
-}
-
-  .jump-links .container {
-    width: 100%;
-    padding-right: 20px;
-    padding-left: 20px;
-    margin-right: auto;
-    margin-left: auto;
-  }
-
 .jump-links {
   margin-bottom: 6rem;
   margin-top: 2rem;
@@ -33,6 +11,28 @@ div.jump-links .column {
   height: 9rem;
 }
 
+.jump-links .container {
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.jump-links .row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -20px;
+  margin-left: -20px;
+}
+
+.jump-links .column {
+  flex: 0 0 100%;
+  max-width: 100%;
+  position: relative;
+  box-sizing: border-box;
+}
+
 .jump-links-jump-link {
   border-bottom: .1rem solid #dcdde6;
   padding: 3rem 0;
@@ -40,24 +40,11 @@ div.jump-links .column {
   transition: margin .25s ease;
 }
 
-
 .jump-links .vlt-icon-arrow-link,.jump-links-title {
   font-family: var(--body-font-family);
   font-size: 1.7rem;
   letter-spacing: -.025rem;
   line-height: 2.5rem;
-}
-
-@media (min-width: 768px) {
-  .jump-links-jump-link {
-    border-bottom: none;
-  }
-}
-
-@media (min-width: 768px) {
-  .jump-links-spacer {
-    display: block;
-  }
 }
 
 .jump-links-jump-link:hover .vlt-icon-arrow-link {
@@ -124,58 +111,21 @@ div.jump-links .column {
   font-family: var(--icon-font-family);
 }
 
-@media (min-width: 768px) {
-  .jump-links .container {
-    margin-top:-9rem;
-  }
-}
-
 @media (min-width: 576px) {
   .jump-links .container {
     max-width: 540px;
   }
-}
 
-@media (min-width: 768px) {
-  .jump-links .container {
-    max-width: 45pc;
-  }
-}
-
-@media (min-width: 992px) {
-  .jump-links .container {
-    max-width: 990pt;
-  }
-}
-
-
-@media (min-width: 1200px) {
-  .jump-links .container {
-    margin-top:-13rem;
-  }
-}
-
-@media (min-width: 576px) {
   .jump-links .col-12:nth-child(n+3) {
     margin-top:2rem;
   }
 }
 
-@media (min-width: 992px) {
-  .jump-links .col-12:nth-child(n+3) {
-    margin-top:0;
-  }
-}
-
 @media (min-width: 768px) {
-  div.jump-links .column {
-    -webkit-box-flex: 0;
-    flex: 0 0 50%;
-    max-width: 50%;
-    position: relative;
-    width: 100%;
-    padding-right: 20px;
-    padding-left: 20px;
+  .jump-links-jump-link {
+    border-bottom: none;
+    padding-left:3rem;
+    padding-right: 3rem;
   }
 
   .jump-links-spacer {
@@ -186,25 +136,70 @@ div.jump-links .column {
     position: relative;
     top: -3rem;
   }
-}
 
-@media (min-width: 1200px) {
-  .jump-links-spacer {
-    height:13rem;
+  .jump-links .container {
+    margin-top:-9rem;
+    max-width: 45pc;
   }
-}
 
-@media (min-width: 768px) {
-  .jump-links-jump-link {
-    padding-left:3rem;
-    padding-right: 3rem;
-    border-bottom: none;
+  .jump-links .column {
+    -webkit-box-flex: 0;
+    flex: 0 0 50%;
+    max-width: 50%;
+    position: relative;
+    width: 100%;
+    padding-right: 20px;
+    padding-left: 20px;
   }
-}
 
-@media (min-width: 768px) {
   .jump-links-jump-link:hover .jump-links-link {
     margin:-1rem;
+  }
+
+  .jump-links-heading {
+    -webkit-box-align:center;
+    -ms-flex-align: center;
+    align-items: center;
+    display: block;
+  }
+
+  .jump-links-icon {
+    display:block;
+    margin-bottom: 1.5rem;
+    margin-right: 0;
+  }
+
+  .jump-links-label {
+    font-family: var(--body-font-family);
+    font-size: 1.2rem;
+    font-weight: 400;
+    letter-spacing: 0;
+    line-height: 1.6rem;
+    padding-right:21.5%;
+  }
+
+  .jump-links-title {
+    font-family: var(--body-font-family);
+    font-size: 1.7rem;
+    font-weight: 400;
+    letter-spacing: -.025rem;
+    line-height: 2.5rem;
+  }
+
+  .jump-links .vlt-icon-arrow-link {
+    font-family: var(--body-font-family);
+    font-size: 1.7rem;
+    font-weight: 400;
+    letter-spacing: -.025rem;
+    line-height: 2.5rem;
+    bottom:.3rem;
+  }
+
+  .jump-links-link {
+    border-bottom:none;
+    border-radius: 2rem;
+    box-shadow: 0 .2rem 1.4rem 0 hsl(0deg 0% 58.4% / 28%);
+    transition: margin .25s ease;
   }
 }
 
@@ -214,26 +209,13 @@ div.jump-links .column {
   }
 }
 
-@media (min-width: 768px) {
-  .jump-links-heading {
-    -webkit-box-align:center;
-    -ms-flex-align: center;
-    align-items: center;
-    display: block;
+@media (min-width: 992px) {
+  .jump-links .container {
+    max-width: 990pt;
   }
-}
 
-@media (min-width: 1200px) {
-  .jump-links-heading {
-    display:block;
-  }
-}
-
-@media (min-width: 768px) {
-  .jump-links-icon {
-    display:block;
-    margin-bottom: 1.5rem;
-    margin-right: 0;
+  .jump-links .col-12:nth-child(n+3) {
+    margin-top:0;
   }
 }
 
@@ -241,52 +223,25 @@ div.jump-links .column {
   .jump-links-icon {
     margin-bottom:3rem;
   }
-}
 
-@media (min-width: 768px) {
-  .jump-links-label {
-    font-family: var(--body-font-family);
-    font-size: 1.2rem;
-    font-weight: 400;
-    letter-spacing: 0;
-    line-height: 1.6rem;
+  .jump-links .container {
+    margin-top:-13rem;
   }
-}
 
-@media (min-width: 1200px) {
+  .jump-links-heading {
+    display:block;
+  }
+
   .jump-links-label {
     font-family: var(--body-font-family);
     font-size: 1.2rem;
     font-weight: 400;
     letter-spacing: .025rem;
     line-height: 1.6rem;
-  }
-}
-
-@media (min-width: 768px) {
-  .jump-links-label {
-    padding-right:21.5%;
-  }
-}
-
-@media (min-width: 1200px) {
-  .jump-links-label {
     margin-top:1.2rem;
     padding-right: 22.7%;
   }
-}
 
-@media (min-width: 768px) {
-  .jump-links-title {
-    font-family: var(--body-font-family);
-    font-size: 1.7rem;
-    font-weight: 400;
-    letter-spacing: -.025rem;
-    line-height: 2.5rem;
-  }
-}
-
-@media (min-width: 1200px) {
   .jump-links-title {
     font-family: var(--body-font-family);
     font-size: 2.1rem;
@@ -294,25 +249,7 @@ div.jump-links .column {
     letter-spacing: -.025rem;
     line-height: 2.4rem;
   }
-}
 
-@media (min-width: 768px) {
-  .jump-links-title {
-    line-height:normal;
-  }
-}
-
-@media (min-width: 768px) {
-  .jump-links .vlt-icon-arrow-link {
-    font-family: var(--body-font-family);
-    font-size: 1.7rem;
-    font-weight: 400;
-    letter-spacing: -.025rem;
-    line-height: 2.5rem;
-  }
-}
-
-@media (min-width: 1200px) {
   .jump-links .vlt-icon-arrow-link {
     font-family: var(--body-font-family);
     font-size: 2.1rem;
@@ -320,19 +257,8 @@ div.jump-links .column {
     letter-spacing: -.025rem;
     line-height: 2.4rem;
   }
-}
 
-@media (min-width: 768px) {
-  .jump-links .vlt-icon-arrow-link {
-    bottom:.3rem;
-  }
-}
-
-@media (min-width: 768px) {
-  .jump-links-link {
-    border-bottom:none;
-    border-radius: 2rem;
-    box-shadow: 0 .2rem 1.4rem 0 hsl(0deg 0% 58.4% / 28%);
-    transition: margin .25s ease;
+  .jump-links-spacer {
+    height:13rem;
   }
 }

--- a/blocks/jump-links/jump-links.js
+++ b/blocks/jump-links/jump-links.js
@@ -16,7 +16,7 @@ export default function decorate(block) {
   linkTexts.forEach((linkText, index) => {
     const column = div({ class: 'column' });
     column.innerHTML = `<div class="jump-links-jump-link">
-    <a class="jump-links-link" href="javascript:void(0)" data-target="${linkTargets[index].getAttribute('href')}"></a>
+    <a class="jump-links-link" href="${linkTargets[index].getAttribute('href')}"</a>
     <div class="jump-links-heading">
       <div class="jump-links-icon">
       </div>

--- a/blocks/jump-links/jump-links.js
+++ b/blocks/jump-links/jump-links.js
@@ -1,0 +1,30 @@
+import { div } from '../../scripts/scripts.js';
+
+export default function decorate(block) {
+  const cols = [...block.firstElementChild.children];
+  block.classList.add(`jump-links-${cols.length}-cols`);
+
+  const linkTexts = [...block.querySelectorAll('.jump-links h2')];
+  const linkTargets = [...block.querySelectorAll('.jump-links a')];
+
+  block.innerHTML = `
+    <div class="jump-links-spacer "></div>
+    <div class="container">
+        <div class="row"></div>
+    </div>`;
+
+  linkTexts.forEach((linkText, index) => {
+    const column = div({ class: 'column' });
+    column.innerHTML = `<div class="jump-links-jump-link">
+    <a class="jump-links-link" href="javascript:void(0)" data-target="${linkTargets[index].getAttribute('href')}"></a>
+    <div class="jump-links-heading">
+      <div class="jump-links-icon">
+      </div>
+      <h2 class="jump-links-title">${linkText.innerText}</h2>
+      <span class="vlt-icon-arrow-link" aria-hidden="true"></span>
+    </div>
+    <span class="jump-links-label"></span>`;
+
+    block.querySelector('div.row').appendChild(column);
+  });
+}


### PR DESCRIPTION
New block jumpLinks, only seen used in the global-calling-plans page but necessary IMHO. 


Fix #136

Test URLs:
Before: https://main--vonage--hlxsites.hlx.page/unified-communications/global/global-calling-plans
After: https://issue-136-jumpLinks--vonage--hlxsites.hlx.page/unified-communications/global/global-calling-plans
