### PR TITLE
Issue 137 pricing grid

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -435,6 +435,7 @@ div.columns.text-list>div>div {
 div.section.headerlists{
   padding: 0;
   margin-top: -2rem;
+  margin-bottom: 9rem;
 }
 
 div.section.headerlists div.columns.block > div {
@@ -445,6 +446,7 @@ div.section.headerlists div.columns.block > div {
   max-width: 45pc;
   margin-left: auto;
   margin-right: auto;
+  align-items: flex-start;
 }
 
 div.section.headerlists div.columns-other-col {
@@ -464,7 +466,7 @@ div.section.headerlists div.default-content-wrapper:first-child {
   padding-bottom: 7rem;
 }
 
-div.section.headerlists div.default-content-wrapper:first-child p::after {
+div.section.headerlists div.default-content-wrapper:first-child *::after {
   background: -webkit-gradient(linear,left top,right top,from(#881fff),to(#7fc8f5));
   background: linear-gradient(90deg,#881fff 0,#7fc8f5);
   bottom: 0;
@@ -509,6 +511,11 @@ div.section.headerlists div.columns-other-col li {
   padding-left:0.7rem;
 }
 
+div.section.headerlists div.columns-wrapper {
+  border-bottom: 0.1rem solid #dcdde6;
+}
+
+
 @media (min-width: 768px) {
   div.section.headerlists div.default-content-wrapper:first-child > p {
     max-width: 50%;
@@ -551,6 +558,17 @@ div.section.headerlists div.columns-other-col li {
       margin-top: -20rem;
     }
 
+    div.section.headerlists .default-content-wrapper > h2 {
+      color: white;
+      font-size: 4rem;
+      padding-top: 8rem;
+    }
+
+    div.section.headerlists .columns-wrapper h2 {
+      color: white;
+      font-size: 3rem;
+    }
+
     div.section.headerlists div.default-content-wrapper:first-child > p {
       max-width: 50%;
       margin-left: 50%;
@@ -580,14 +598,12 @@ div.section.headerlists div.columns-other-col li {
     font-weight: 400;
     letter-spacing: .025rem;
     line-height: 1.6rem;
-    border-top: 0.1rem solid #c1c3cd;
     padding-top: 1.5rem;
     color: #5f6169;
     text-align: left;
   }
 
   div.section.headerlists div:nth-child(3) {
-    padding:5rem 2rem;
     box-sizing: border-box;
     max-width: 990pt;
   }

--- a/blocks/jump-links/jump-links.css
+++ b/blocks/jump-links/jump-links.css
@@ -96,7 +96,7 @@
   transition: bottom .25s ease;
 }
 
-.jump-links-link:any-link {
+.jump-links-link {
   background-color: #fff;
   border-radius: 2rem;
   bottom: 0;
@@ -104,11 +104,6 @@
   position: absolute;
   right: 0;
   top: 0;
-  color:black;
-}
-
-.jump-links-link:any-link:hover {
-text-decoration:none;
 }
 
 .vlt-icon-arrow-link::before {

--- a/blocks/jump-links/jump-links.css
+++ b/blocks/jump-links/jump-links.css
@@ -19,6 +19,10 @@
   margin-left: auto;
 }
 
+.section.jump-links-container {
+  padding: 0;
+}
+
 .jump-links .row {
   display: flex;
   flex-wrap: wrap;

--- a/blocks/jump-links/jump-links.js
+++ b/blocks/jump-links/jump-links.js
@@ -16,7 +16,7 @@ export default function decorate(block) {
   linkTexts.forEach((linkText, index) => {
     const column = div({ class: 'column' });
     column.innerHTML = `<div class="jump-links-jump-link">
-    <a class="jump-links-link" href="${linkTargets[index].getAttribute('href')}"</a>
+    <a class="jump-links-link" href="javascript:void(0)" data-target="${linkTargets[index].getAttribute('href')}"></a>
     <div class="jump-links-heading">
       <div class="jump-links-icon">
       </div>

--- a/blocks/jump-links/jump-links.js
+++ b/blocks/jump-links/jump-links.js
@@ -16,7 +16,7 @@ export default function decorate(block) {
   linkTexts.forEach((linkText, index) => {
     const column = div({ class: 'column' });
     column.innerHTML = `<div class="jump-links-jump-link">
-    <a class="jump-links-link" href="javascript:void(0)" data-target="${linkTargets[index].getAttribute('href')}"></a>
+    <a class="jump-links-link" href="${linkTargets[index].getAttribute('href')}"></a>
     <div class="jump-links-heading">
       <div class="jump-links-icon">
       </div>

--- a/blocks/pricing-grid/pricing-grid.css
+++ b/blocks/pricing-grid/pricing-grid.css
@@ -1,0 +1,360 @@
+
+*, :after, :before {
+  box-sizing: inherit;
+}
+
+.pricing-grid .container {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.pricing-grid .row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -20px;
+  margin-left: -20px;
+}
+
+.pricing-grid .col-12 {
+  flex: 0 0 100%;
+  max-width: 100%;
+  position: relative;
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px;
+}
+
+.pricing-grid .category-grid__header {
+  margin-bottom: 5rem;
+  position: relative;
+}
+
+.pricing-grid .category-grid__header-title {
+  font-size: 1.8rem;
+  font-weight: 500;
+  letter-spacing: -.05rem;
+  line-height: 2.4rem;
+  word-break: break-word;
+  font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+  margin-left: 5.8rem;
+}
+
+.pricing-grid .category-grid .aem-Grid.row {
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+}
+
+.pricing-grid .tabs {
+  background-color: #eeeffc;
+  overflow: hidden;
+}
+
+.pricing-grid .tabs__tabs {
+  height: 7.0rem;
+  overflow: auto;
+  padding: .5rem;
+  white-space: nowrap;
+}
+
+.pricing-grid .tabs__tab {
+  background: none;
+  border-radius: 0;
+  border: 0 solid #000;
+  color: #000;
+  cursor: pointer;
+  display: inline-block;
+  height: auto;
+  padding: 0;
+  font-family: Spezia_SemiMono;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: .075rem;
+  line-height: 2rem;
+  text-transform: uppercase;
+  outline: none;
+}
+
+.pricing-grid .tabs__tab:after {
+  content: "";
+  display: block;
+  height: .2rem;
+  width: 100%;
+  background-color: #881fff;
+}
+
+.pricing-grid .tabs__tab:not([aria-selected=true]) {
+  opacity: .58;
+}
+
+.pricing-grid .tabs__tab:nth-child(n+2) {
+  margin-left: 3rem;
+}
+
+.pricing-grid .pricing-card {
+  background-color: #eeeffc;
+  padding-bottom: 7rem;
+}
+
+.pricing-grid .pricing-card__card {
+  background-color: #fff;
+  border-radius: 2rem;
+  padding: 4rem 3rem;
+}
+
+.pricing-grid .pricing-card__option:first-child {
+  margin-top: 0;
+}
+
+.pricing-grid .pricing-card__option {
+  margin-top: 5rem;
+}
+
+.pricing-grid .pricing-card__option-product {
+  font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+  font-size: 1.8rem;
+  font-weight: 500;
+  letter-spacing: -.05rem;
+  line-height: 2.4rem;
+  margin-bottom: 2rem;
+}
+
+.pricing-grid .pricing-card__offer {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.pricing-card__offer+.pricing-card__offer {
+  border-top: .1rem solid #dcdde6;
+  margin-top: 2rem;
+  padding-top: 2rem;
+}
+
+.pricing-grid .pricing-card__offer-name, .pricing-grid .pricing-card__offer-price {
+  font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+  font-size: 1.4rem;
+  font-weight: 400;
+  letter-spacing: -.02rem;
+  line-height: 2rem;
+  display: block;
+}
+
+.pricing-grid .end-note__content {
+  font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+  font-size: 1.2rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.6rem;
+  color: #5f6169;
+  text-align: left;
+}
+
+.pricing-grid .pricing-card__offer-price {
+  font-weight: 700;
+  text-align: right;
+}
+
+.pricing-grid .pricing-card .end-note {
+  margin-top: 3rem;
+}
+
+@media (min-width: 576px) {
+
+  .pricing-grid .container {
+    max-width: 540px;
+  }
+}
+
+@media (min-width: 768px) {
+
+  .pricing-grid .container {
+    max-width: 45pc;
+  }
+
+  .pricing-grid .category-grid__header {
+    margin-bottom: 7.2rem;
+  }
+
+  .pricing-grid .category-grid__header-title {
+    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-size: 1.8rem;
+    font-weight: 500;
+    letter-spacing: -.05rem;
+    line-height: 2rem;
+  }
+
+  .pricing-grid .category-grid .aem-Grid, .pricing-grid .category-grid__items {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .pricing-grid .category-grid .aem-Grid, .pricing-grid .category-grid__items {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+  }
+
+  .pricing-grid .tabs__tab {
+    height: auto;
+    padding-left: 0;
+    padding-right: 0;
+    font-family: Spezia_SemiMono;
+    font-size: 1.4rem;
+    font-weight: 600;
+    letter-spacing: .075rem;
+    line-height: 2rem;
+  }
+
+  .pricing-grid .pricing-card__card {
+    padding: 6rem 5.8rem;
+  }
+
+  .pricing-grid .pricing-card__option {
+    margin-top: 0;
+  }
+
+  .pricing-grid .pricing-card__option-product {
+    margin-bottom: 4rem;
+  }
+
+  .pricing-grid .pricing-card__option-product {
+    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-size: 1.8rem;
+    font-weight: 500;
+    letter-spacing: -.05rem;
+    line-height: 2rem;
+  }
+
+  .pricing-grid  .pricing-card__offer-name, .pricing-grid .pricing-card__offer-price {
+    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-size: 1.4rem;
+    font-weight: 400;
+    letter-spacing: -.02rem;
+    line-height: 2rem;
+  }
+
+  .pricing-grid .pricing-card .end-note {
+    margin-top: 5rem;
+  }
+
+  .pricing-grid .end-note__content {
+    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-size: 1.2rem;
+    font-weight: 400;
+    letter-spacing: 0;
+    line-height: 1.6rem;
+  }
+
+}
+
+  @media (min-width: 992px) {
+
+    .pricing-grid .container {
+      max-width: 990pt;
+    }
+
+    .pricing-grid .col-lg-3 {
+      -webkit-box-flex: 0;
+      flex: 0 0 25%;
+      max-width: 25%;
+    }
+
+    .pricing-grid .category-grid__header {
+      margin-bottom: 0;
+      overflow: visible;
+    }
+
+    .pricing-grid .category-grid__header-title {
+      margin-left: 5.3rem;
+    }
+
+    .pricing-grid .col-lg-9 {
+      flex: 0 0 75%;
+      max-width: 75%;
+    }
+
+    .pricing-grid .pricing-card {
+      padding-bottom: 9rem;
+    }
+
+    .pricing-grid .pricing-card__card {
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex;
+      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+      -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+      justify-content: space-between;
+      padding: 7rem 5rem;
+    }
+
+    .pricing-grid .pricing-card__option {
+      -ms-flex-preferred-size: 44.06779%;
+      flex-basis: 44.06779%;
+      margin-top: 0;
+    }
+
+    .pricing-grid .pricing-card__option-product {
+      margin-bottom: 5rem;
+    }
+
+    .pricing-grid .end-note__content {
+      max-width: 74.6rem;
+    }
+  }
+
+@media (min-width: 1200px) {
+  .pricing-grid  .category-grid__header-title {
+    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-size: 2.1rem;
+    font-weight: 500;
+    letter-spacing: -.05rem;
+    line-height: 2.4rem;
+  }
+
+  .pricing-grid .tabs__tab {
+    font-family: Spezia_SemiMono;
+    font-size: 1.4rem;
+    font-weight: 600;
+    letter-spacing: .075rem;
+    line-height: 2rem;
+  }
+
+  .pricing-grid .pricing-card__option-product {
+    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-size: 2.1rem;
+    font-weight: 500;
+    letter-spacing: -.05rem;
+    line-height: 2.4rem;
+  }
+
+  .pricing-grid .pricing-card__offer-name, .pricing-grid .pricing-card__offer-price {
+    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-size: 1.7rem;
+    font-weight: 400;
+    letter-spacing: -.02rem;
+    line-height: 2rem;
+  }
+
+  .pricing-grid .end-note__content {
+    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-size: 1.2rem;
+    font-weight: 400;
+    letter-spacing: .025rem;
+    line-height: 1.6rem;
+  }
+}

--- a/blocks/pricing-grid/pricing-grid.css
+++ b/blocks/pricing-grid/pricing-grid.css
@@ -1,5 +1,5 @@
 
-*, :after, :before {
+*, ::after, ::before {
   box-sizing: inherit;
 }
 
@@ -28,22 +28,22 @@
   padding-left: 20px;
 }
 
-.pricing-grid .category-grid__header {
+.pricing-grid .category-grid-header {
   margin-bottom: 5rem;
   position: relative;
 }
 
-.pricing-grid .category-grid__header-title {
+.pricing-grid .category-grid-header-title {
   font-size: 1.8rem;
   font-weight: 500;
   letter-spacing: -.05rem;
   line-height: 2.4rem;
   word-break: break-word;
-  font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+  font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
   margin-left: 5.8rem;
 }
 
-.pricing-grid .category-grid .aem-Grid.row {
+.pricing-grid .category-grid .aem-grid.row {
   margin-left: auto;
   margin-right: auto;
   width: 100%;
@@ -52,6 +52,18 @@
 .pricing-grid .tabs {
   background-color: #eeeffc;
   overflow: hidden;
+}
+
+.pricing-grid .tabs__tab:not([aria-selected="true"])::after {
+  content: none;
+}
+
+.pricing-grid .tabs [role="tab-panel"][aria-hidden="true"] {
+  display: none;
+}
+
+.pricing-grid .tabs__tab:not([aria-selected="true"]) {
+  opacity: .58;
 }
 
 .pricing-grid .tabs__tabs {
@@ -70,7 +82,7 @@
   display: inline-block;
   height: auto;
   padding: 0;
-  font-family: Spezia_SemiMono;
+  font-family: "Spezia_SemiMono";
   font-size: 1.4rem;
   font-weight: 600;
   letter-spacing: .075rem;
@@ -79,7 +91,7 @@
   outline: none;
 }
 
-.pricing-grid .tabs__tab:after {
+.pricing-grid .tabs__tab::after {
   content: "";
   display: block;
   height: .2rem;
@@ -87,7 +99,7 @@
   background-color: #881fff;
 }
 
-.pricing-grid .tabs__tab:not([aria-selected=true]) {
+.pricing-grid .tabs__tab:not([aria-selected="true"]) {
   opacity: .58;
 }
 
@@ -115,7 +127,7 @@
 }
 
 .pricing-grid .pricing-card__option-product {
-  font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+  font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
   font-size: 1.8rem;
   font-weight: 500;
   letter-spacing: -.05rem;
@@ -125,11 +137,11 @@
 
 .pricing-grid .pricing-card__offer {
   display: -webkit-box;
-  display: -ms-flexbox;
+  display: flexbox;
   display: flex;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
-  -ms-flex-direction: row;
+  flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: justify;
   -ms-flex-pack: justify;
@@ -143,7 +155,7 @@
 }
 
 .pricing-grid .pricing-card__offer-name, .pricing-grid .pricing-card__offer-price {
-  font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+  font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
   font-size: 1.4rem;
   font-weight: 400;
   letter-spacing: -.02rem;
@@ -152,7 +164,7 @@
 }
 
 .pricing-grid .end-note__content {
-  font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+  font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
   font-size: 1.2rem;
   font-weight: 400;
   letter-spacing: 0;
@@ -171,39 +183,38 @@
 }
 
 @media (min-width: 576px) {
-
   .pricing-grid .container {
     max-width: 540px;
   }
 }
 
 @media (min-width: 768px) {
-
   .pricing-grid .container {
     max-width: 45pc;
   }
 
-  .pricing-grid .category-grid__header {
+  .pricing-grid .category-grid-header {
     margin-bottom: 7.2rem;
   }
 
-  .pricing-grid .category-grid__header-title {
-    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+  .pricing-grid .category-grid-header-title {
+    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 1.8rem;
     font-weight: 500;
     letter-spacing: -.05rem;
     line-height: 2rem;
   }
 
-  .pricing-grid .category-grid .aem-Grid, .pricing-grid .category-grid__items {
+  .pricing-grid .category-grid .aem-grid, .pricing-grid .category-grid__items {
     display: flex;
     flex-wrap: wrap;
   }
-  .pricing-grid .category-grid .aem-Grid, .pricing-grid .category-grid__items {
+
+  .pricing-grid .category-grid .aem-grid, .pricing-grid .category-grid__items {
     display: -webkit-box;
-    display: -ms-flexbox;
+    display: flexbox;
     display: flex;
-    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
     flex-wrap: wrap;
   }
 
@@ -211,7 +222,7 @@
     height: auto;
     padding-left: 0;
     padding-right: 0;
-    font-family: Spezia_SemiMono;
+    font-family: "Spezia_SemiMono";
     font-size: 1.4rem;
     font-weight: 600;
     letter-spacing: .075rem;
@@ -231,7 +242,7 @@
   }
 
   .pricing-grid .pricing-card__option-product {
-    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 1.8rem;
     font-weight: 500;
     letter-spacing: -.05rem;
@@ -239,7 +250,7 @@
   }
 
   .pricing-grid  .pricing-card__offer-name, .pricing-grid .pricing-card__offer-price {
-    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 1.4rem;
     font-weight: 400;
     letter-spacing: -.02rem;
@@ -251,7 +262,7 @@
   }
 
   .pricing-grid .end-note__content {
-    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 1.2rem;
     font-weight: 400;
     letter-spacing: 0;
@@ -261,7 +272,6 @@
 }
 
   @media (min-width: 992px) {
-
     .pricing-grid .container {
       max-width: 990pt;
     }
@@ -272,12 +282,12 @@
       max-width: 25%;
     }
 
-    .pricing-grid .category-grid__header {
+    .pricing-grid .category-grid-header {
       margin-bottom: 0;
       overflow: visible;
     }
 
-    .pricing-grid .category-grid__header-title {
+    .pricing-grid .category-grid-header-title {
       margin-left: 5.3rem;
     }
 
@@ -292,9 +302,9 @@
 
     .pricing-grid .pricing-card__card {
       display: -webkit-box;
-      display: -ms-flexbox;
+      display: flexbox;
       display: flex;
-      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
       flex-wrap: wrap;
       -webkit-box-pack: justify;
       -ms-flex-pack: justify;
@@ -318,8 +328,8 @@
   }
 
 @media (min-width: 1200px) {
-  .pricing-grid  .category-grid__header-title {
-    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+  .pricing-grid  .category-grid-header-title {
+    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 2.1rem;
     font-weight: 500;
     letter-spacing: -.05rem;
@@ -327,7 +337,7 @@
   }
 
   .pricing-grid .tabs__tab {
-    font-family: Spezia_SemiMono;
+    font-family: "Spezia_SemiMono";
     font-size: 1.4rem;
     font-weight: 600;
     letter-spacing: .075rem;
@@ -335,7 +345,7 @@
   }
 
   .pricing-grid .pricing-card__option-product {
-    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 2.1rem;
     font-weight: 500;
     letter-spacing: -.05rem;
@@ -343,7 +353,7 @@
   }
 
   .pricing-grid .pricing-card__offer-name, .pricing-grid .pricing-card__offer-price {
-    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 1.7rem;
     font-weight: 400;
     letter-spacing: -.02rem;
@@ -351,7 +361,7 @@
   }
 
   .pricing-grid .end-note__content {
-    font-family: Spezia,Spezia_SemiMono,Arial,Helvetica,sans-serif;
+    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 1.2rem;
     font-weight: 400;
     letter-spacing: .025rem;

--- a/blocks/pricing-grid/pricing-grid.css
+++ b/blocks/pricing-grid/pricing-grid.css
@@ -1,3 +1,4 @@
+/* stylelint-disable no-descending-specificity */
 
 *, ::after, ::before {
   box-sizing: inherit;
@@ -39,7 +40,7 @@
   letter-spacing: -.05rem;
   line-height: 2.4rem;
   word-break: break-word;
-  font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
+  font-family: var(--body-font-family);
   margin-left: 5.8rem;
 }
 
@@ -54,7 +55,7 @@
   overflow: hidden;
 }
 
-.pricing-grid .tabs__tab:not([aria-selected="true"])::after {
+.pricing-grid .tabs-tab:not([aria-selected="true"])::after {
   content: none;
 }
 
@@ -62,18 +63,18 @@
   display: none;
 }
 
-.pricing-grid .tabs__tab:not([aria-selected="true"]) {
+.pricing-grid .tabs-tab:not([aria-selected="true"]) {
   opacity: .58;
 }
 
-.pricing-grid .tabs__tabs {
+.pricing-grid .tabs-tabs {
   height: 7.0rem;
   overflow: auto;
   padding: .5rem;
   white-space: nowrap;
 }
 
-.pricing-grid .tabs__tab {
+.pricing-grid .tabs-tab {
   background: none;
   border-radius: 0;
   border: 0 solid #000;
@@ -82,7 +83,7 @@
   display: inline-block;
   height: auto;
   padding: 0;
-  font-family: "Spezia_SemiMono";
+  font-family: var(--body-font-family);
   font-size: 1.4rem;
   font-weight: 600;
   letter-spacing: .075rem;
@@ -91,7 +92,7 @@
   outline: none;
 }
 
-.pricing-grid .tabs__tab::after {
+.pricing-grid .tabs-tab::after {
   content: "";
   display: block;
   height: .2rem;
@@ -99,11 +100,7 @@
   background-color: #881fff;
 }
 
-.pricing-grid .tabs__tab:not([aria-selected="true"]) {
-  opacity: .58;
-}
-
-.pricing-grid .tabs__tab:nth-child(n+2) {
+.pricing-grid .tabs-tab:nth-child(n+2) {
   margin-left: 3rem;
 }
 
@@ -112,22 +109,22 @@
   padding-bottom: 7rem;
 }
 
-.pricing-grid .pricing-card__card {
+.pricing-grid .pricing-card-card {
   background-color: #fff;
   border-radius: 2rem;
   padding: 4rem 3rem;
 }
 
-.pricing-grid .pricing-card__option:first-child {
+.pricing-grid .pricing-card-option:first-child {
   margin-top: 0;
 }
 
-.pricing-grid .pricing-card__option {
+.pricing-grid .pricing-card-option {
   margin-top: 5rem;
 }
 
-.pricing-grid .pricing-card__option-product {
-  font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
+.pricing-grid .pricing-card-option-product {
+  font-family: var(--body-font-family);
   font-size: 1.8rem;
   font-weight: 500;
   letter-spacing: -.05rem;
@@ -135,27 +132,22 @@
   margin-bottom: 2rem;
 }
 
-.pricing-grid .pricing-card__offer {
-  display: -webkit-box;
-  display: flexbox;
+.pricing-grid .pricing-card-offer {
   display: flex;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
   flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.pricing-card__offer+.pricing-card__offer {
+.pricing-card-offer+.pricing-card-offer {
   border-top: .1rem solid #dcdde6;
   margin-top: 2rem;
   padding-top: 2rem;
 }
 
-.pricing-grid .pricing-card__offer-name, .pricing-grid .pricing-card__offer-price {
-  font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
+.pricing-grid .pricing-card-offer-name, .pricing-grid .pricing-card-offer-price {
+  font-family: var(--body-font-family);
   font-size: 1.4rem;
   font-weight: 400;
   letter-spacing: -.02rem;
@@ -163,7 +155,7 @@
   display: block;
 }
 
-.pricing-grid .end-note__content {
+.pricing-grid .end-note-content {
   font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
   font-size: 1.2rem;
   font-weight: 400;
@@ -173,7 +165,7 @@
   text-align: left;
 }
 
-.pricing-grid .pricing-card__offer-price {
+.pricing-grid .pricing-card-offer-price {
   font-weight: 700;
   text-align: right;
 }
@@ -205,52 +197,41 @@
     line-height: 2rem;
   }
 
-  .pricing-grid .category-grid .aem-grid, .pricing-grid .category-grid__items {
+  .pricing-grid .category-grid .aem-grid, .pricing-grid .category-grid-items {
     display: flex;
     flex-wrap: wrap;
   }
 
-  .pricing-grid .category-grid .aem-grid, .pricing-grid .category-grid__items {
-    display: -webkit-box;
-    display: flexbox;
-    display: flex;
-    flex-wrap: wrap;
-    flex-wrap: wrap;
-  }
-
-  .pricing-grid .tabs__tab {
+  .pricing-grid .tabs-tab {
     height: auto;
     padding-left: 0;
     padding-right: 0;
-    font-family: "Spezia_SemiMono";
+    font-family: var(--body-font-family);
     font-size: 1.4rem;
     font-weight: 600;
     letter-spacing: .075rem;
     line-height: 2rem;
   }
 
-  .pricing-grid .pricing-card__card {
+  .pricing-grid .pricing-card-card {
     padding: 6rem 5.8rem;
   }
 
-  .pricing-grid .pricing-card__option {
+  .pricing-grid .pricing-card-option {
     margin-top: 0;
   }
 
-  .pricing-grid .pricing-card__option-product {
+  .pricing-grid .pricing-card-option-product {
     margin-bottom: 4rem;
-  }
-
-  .pricing-grid .pricing-card__option-product {
-    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
+    font-family: var(--body-font-family);
     font-size: 1.8rem;
     font-weight: 500;
     letter-spacing: -.05rem;
     line-height: 2rem;
   }
 
-  .pricing-grid  .pricing-card__offer-name, .pricing-grid .pricing-card__offer-price {
-    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
+  .pricing-grid  .pricing-card-offer-name, .pricing-grid .pricing-card-offer-price {
+    font-family: var(--body-font-family);
     font-size: 1.4rem;
     font-weight: 400;
     letter-spacing: -.02rem;
@@ -261,7 +242,7 @@
     margin-top: 5rem;
   }
 
-  .pricing-grid .end-note__content {
+  .pricing-grid .end-note-content {
     font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 1.2rem;
     font-weight: 400;
@@ -300,11 +281,8 @@
       padding-bottom: 9rem;
     }
 
-    .pricing-grid .pricing-card__card {
-      display: -webkit-box;
-      display: flexbox;
+    .pricing-grid .pricing-card-card {
       display: flex;
-      flex-wrap: wrap;
       flex-wrap: wrap;
       -webkit-box-pack: justify;
       -ms-flex-pack: justify;
@@ -312,47 +290,46 @@
       padding: 7rem 5rem;
     }
 
-    .pricing-grid .pricing-card__option {
-      -ms-flex-preferred-size: 44.06779%;
-      flex-basis: 44.06779%;
+    .pricing-grid .pricing-card-option {
+      flex-basis: 44.069%;
       margin-top: 0;
     }
 
-    .pricing-grid .pricing-card__option-product {
+    .pricing-grid .pricing-card-option-product {
       margin-bottom: 5rem;
     }
 
-    .pricing-grid .end-note__content {
+    .pricing-grid .end-note-content {
       max-width: 74.6rem;
     }
   }
 
 @media (min-width: 1200px) {
   .pricing-grid  .category-grid-header-title {
-    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
+    font-family: var(--body-font-family);
     font-size: 2.1rem;
     font-weight: 500;
     letter-spacing: -.05rem;
     line-height: 2.4rem;
   }
 
-  .pricing-grid .tabs__tab {
-    font-family: "Spezia_SemiMono";
+  .pricing-grid .tabs-tab {
+    font-family: var(--body-font-family);
     font-size: 1.4rem;
     font-weight: 600;
     letter-spacing: .075rem;
     line-height: 2rem;
   }
 
-  .pricing-grid .pricing-card__option-product {
-    font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
+  .pricing-grid .pricing-card-option-product {
+    font-family: var(--body-font-family);
     font-size: 2.1rem;
     font-weight: 500;
     letter-spacing: -.05rem;
     line-height: 2.4rem;
   }
 
-  .pricing-grid .pricing-card__offer-name, .pricing-grid .pricing-card__offer-price {
+  .pricing-grid .pricing-card-offer-name, .pricing-grid .pricing-card-offer-price {
     font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 1.7rem;
     font-weight: 400;
@@ -360,7 +337,7 @@
     line-height: 2rem;
   }
 
-  .pricing-grid .end-note__content {
+  .pricing-grid .end-note-content {
     font-family: Spezia,"Spezia_SemiMono",Arial,Helvetica,sans-serif;
     font-size: 1.2rem;
     font-weight: 400;

--- a/blocks/pricing-grid/pricing-grid.js
+++ b/blocks/pricing-grid/pricing-grid.js
@@ -5,21 +5,43 @@ import {
 const currencyLabels = [
   { currency: 'usd', label: '$US', symbol: '$' },
   { currency: 'euro', label: '€EURO', symbol: '€' }];
+
+function handleTabButtonClick(event) {
+  if (event.target.getAttribute('aria-selected') === 'false') {
+    const tabIndex = event.target.getAttribute('tabindex');
+    document.querySelectorAll('button.tabs__tab').forEach((buttonElem) => {
+      buttonElem.setAttribute('aria-selected', buttonElem.getAttribute('aria-selected') === 'false' ? 'true' : 'false');
+      document.querySelectorAll(`div.tabs__panel:not([tabindex="${tabIndex}"])`).forEach((tabElem) => {
+        tabElem.setAttribute('aria-hidden', 'true');
+      });
+      document.querySelector(`div.tabs__panel[tabindex="${tabIndex}"]`).setAttribute('aria-hidden', 'false');
+    });
+  }
+}
+
 function populatePricingGrid(block, currencies, pricingData, endNoteContent) {
   currencies.forEach((currency, index) => {
     const currencyIndex = currencyLabels.findIndex((item) => item.currency === currency);
     const currencyLabel = currencyLabels[currencyIndex].label;
     const currencySymbol = currencyLabels[currencyIndex].symbol;
 
+    // Check if the block already has a button, if not set the first button as true for selected, otherwise set false for not
+    const selectedVal = !block.querySelector('button.tabs__tab');
+
     const tabButtonElem = button({
-      class: 'tabs__tab', 'aria-controls': 'panel', 'aria-selected': true, id: 'tab', role: 'tab', tabIndex: index, innerHTML: currencyLabel,
+      class: 'tabs__tab', 'aria-controls': 'panel', 'aria-selected': selectedVal, id: 'tab', role: 'tab', tabIndex: index, innerHTML: currencyLabel,
     });
+
+    tabButtonElem.addEventListener('click', handleTabButtonClick);
     block.querySelector('div.tabs__tabs').append(tabButtonElem);
+
+    // Check if the block already has a tab, if not set the first tab as false for hidden, otherwise set true for hidden
+    const hiddenVal = !!block.querySelector('section.product-card-tabbed .tabs__panel');
 
     // Built by appending pricingCardOption elements to the pricing-card__card div container
     const tabElem = div(
       {
-        class: 'tabs__panel', tabIndex: index, 'aria-hidden': true, id: 'panel', role: 'tabPanel',
+        class: 'tabs__panel', tabIndex: index, 'aria-hidden': hiddenVal, id: 'panel', role: 'tab-panel',
       },
       div(
         { class: 'pricing-card' },

--- a/blocks/pricing-grid/pricing-grid.js
+++ b/blocks/pricing-grid/pricing-grid.js
@@ -1,0 +1,129 @@
+import {
+  button, div, h3, p, span,
+} from '../../scripts/scripts.js';
+
+const currencyLabels = [
+  { currency: 'usd', label: '$US', symbol: '$' },
+  { currency: 'euro', label: '€EURO', symbol: '€' }];
+function populatePricingGrid(block, currencies, pricingData, endNoteContent) {
+  currencies.forEach((currency, index) => {
+    const currencyIndex = currencyLabels.findIndex((item) => item.currency === currency);
+    const currencyLabel = currencyLabels[currencyIndex].label;
+    const currencySymbol = currencyLabels[currencyIndex].symbol;
+
+    const tabButtonElem = button({
+      class: 'tabs__tab', 'aria-controls': 'panel', 'aria-selected': true, id: 'tab', role: 'tab', tabIndex: index, innerHTML: currencyLabel,
+    });
+    block.querySelector('div.tabs__tabs').append(tabButtonElem);
+
+    // Built by appending pricingCardOption elements to the pricing-card__card div container
+    const tabElem = div(
+      {
+        class: 'tabs__panel', tabIndex: index, 'aria-hidden': true, id: 'panel', role: 'tabPanel',
+      },
+      div(
+        { class: 'pricing-card' },
+        div(
+          { class: 'container' },
+          div(
+            { class: 'row' },
+            div(
+              { class: 'col-12' },
+              div({ class: 'pricing-card__card not-dynamic' }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    pricingData.forEach((tier) => {
+      // Built out by appending pricingCardOffer elements to the main div based on the supplied data
+      const pricingCardOption = div(
+        { class: 'pricing-card__option' },
+        h3({ class: 'pricing-card__option-product', innerHTML: tier.data[0].label }),
+      );
+
+      tier.data.forEach((pricingRow) => {
+        // Built by instantiating while providing the values per row of the returned pricing data
+        const pricingCardOffer = div(
+          { class: 'pricing-card__offer' },
+          span({ class: 'pricing-card__offer-name', innerHTML: Number(pricingRow[currency]).toLocaleString('en-US') }),
+          div(
+            { class: 'pricing-card__offer-price-container' },
+            span({ class: 'pricing-card__offer-price', innerHTML: currencySymbol + Number(pricingRow[currency]).toLocaleString('en-US') }),
+          ),
+        );
+        pricingCardOption.append(pricingCardOffer);
+      });
+      tabElem.querySelector('.pricing-card__card').append(pricingCardOption);
+    });
+
+    const endNoteElem = div(
+      { class: 'end-note' },
+      div(
+        { class: 'end-note__content' },
+        p({ innerHTML: endNoteContent }),
+      ),
+    );
+    tabElem.querySelector('.col-12').append(endNoteElem);
+    block.querySelector('section.product-card-tabbed').append(tabElem);
+  });
+}
+export default async function decorate(block) {
+  const currencies = [];
+
+  block.querySelectorAll('li').forEach((currency) => {
+    currencies.push(currency.innerText);
+  });
+
+  const endNoteContent = block.querySelector('h3').innerText;
+
+  block.innerHTML = `
+  <div class="container">
+    <div class="category-grid__group">
+      <div class="row">
+        <div class="col-12 col-lg-3">
+          <div class="category-grid__header">
+            <h2 class="category-grid__header-title">Pricing</h2>
+          </div>
+        </div>
+        <div class="col-12 col-lg-9">
+          <div class="category-grid__items three-col">
+            <div class="aem-Grid aem-Grid--12 aem-Grid--default--12  row">
+              <div class="productPricingTabs aem-GridColumn aem-GridColumn--default--12">
+                <section id="product-card-tabbed" class="tabs product-card-tabbed">
+                  <div class="container">
+                    <div class="row">
+                      <div class="col-12">
+                        <div role="tablist" aria-label="SMS" class="tabs__tabs">
+                            <!--  Tab button elements populated here while iterating through the returned pricing data-->
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <!--  Tab elements populated here while iterating through the returned pricing data-->
+                </section>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+`;
+
+  // Fetch pricing data
+  const resp = await fetch(`${window.location.pathname}/pricing/data.json`);
+
+  if (resp.ok) {
+    const rawData = await resp.json();
+
+    const pricingData = [];
+    if (rawData && rawData[':names'].length !== 0) {
+      rawData[':names'].sort().forEach((tierName) => {
+        pricingData.push({ tier: tierName, data: rawData[tierName].data });
+      });
+    }
+    populatePricingGrid(block, currencies, pricingData, endNoteContent);
+  }
+}

--- a/blocks/pricing-grid/pricing-grid.js
+++ b/blocks/pricing-grid/pricing-grid.js
@@ -9,12 +9,12 @@ const currencyLabels = [
 function handleTabButtonClick(event) {
   if (event.target.getAttribute('aria-selected') === 'false') {
     const tabIndex = event.target.getAttribute('tabindex');
-    document.querySelectorAll('button.tabs__tab').forEach((buttonElem) => {
+    document.querySelectorAll('button.tabs-tab').forEach((buttonElem) => {
       buttonElem.setAttribute('aria-selected', buttonElem.getAttribute('aria-selected') === 'false' ? 'true' : 'false');
-      document.querySelectorAll(`div.tabs__panel:not([tabindex="${tabIndex}"])`).forEach((tabElem) => {
+      document.querySelectorAll(`div.tabs-panel:not([tabindex="${tabIndex}"])`).forEach((tabElem) => {
         tabElem.setAttribute('aria-hidden', 'true');
       });
-      document.querySelector(`div.tabs__panel[tabindex="${tabIndex}"]`).setAttribute('aria-hidden', 'false');
+      document.querySelector(`div.tabs-panel[tabindex="${tabIndex}"]`).setAttribute('aria-hidden', 'false');
     });
   }
 }
@@ -26,22 +26,22 @@ function populatePricingGrid(block, currencies, pricingData, endNoteContent) {
     const currencySymbol = currencyLabels[currencyIndex].symbol;
 
     // Check if the block already has a button, if not set the first button as true for selected, otherwise set false for not
-    const selectedVal = !block.querySelector('button.tabs__tab');
+    const selectedVal = !block.querySelector('button.tabs-tab');
 
     const tabButtonElem = button({
-      class: 'tabs__tab', 'aria-controls': 'panel', 'aria-selected': selectedVal, id: 'tab', role: 'tab', tabIndex: index, innerHTML: currencyLabel,
+      class: 'tabs-tab', 'aria-controls': 'panel', 'aria-selected': selectedVal, id: 'tab', role: 'tab', tabIndex: index, innerHTML: currencyLabel,
     });
 
     tabButtonElem.addEventListener('click', handleTabButtonClick);
-    block.querySelector('div.tabs__tabs').append(tabButtonElem);
+    block.querySelector('div.tabs-tabs').append(tabButtonElem);
 
     // Check if the block already has a tab, if not set the first tab as false for hidden, otherwise set true for hidden
-    const hiddenVal = !!block.querySelector('section.product-card-tabbed .tabs__panel');
+    const hiddenVal = !!block.querySelector('section.product-card-tabbed .tabs-panel');
 
-    // Built by appending pricingCardOption elements to the pricing-card__card div container
+    // Built by appending pricingCardOption elements to the pricing-card-card div container
     const tabElem = div(
       {
-        class: 'tabs__panel', tabIndex: index, 'aria-hidden': hiddenVal, id: 'panel', role: 'tab-panel',
+        class: 'tabs-panel', tabIndex: index, 'aria-hidden': hiddenVal, id: 'panel', role: 'tab-panel',
       },
       div(
         { class: 'pricing-card' },
@@ -51,7 +51,7 @@ function populatePricingGrid(block, currencies, pricingData, endNoteContent) {
             { class: 'row' },
             div(
               { class: 'col-12' },
-              div({ class: 'pricing-card__card not-dynamic' }),
+              div({ class: 'pricing-card-card not-dynamic' }),
             ),
           ),
         ),
@@ -61,29 +61,29 @@ function populatePricingGrid(block, currencies, pricingData, endNoteContent) {
     pricingData.forEach((tier) => {
       // Built out by appending pricingCardOffer elements to the main div based on the supplied data
       const pricingCardOption = div(
-        { class: 'pricing-card__option' },
-        h3({ class: 'pricing-card__option-product', innerHTML: tier.data[0].label }),
+        { class: 'pricing-card-option' },
+        h3({ class: 'pricing-card-option-product', innerHTML: tier.data[0].label }),
       );
 
       tier.data.forEach((pricingRow) => {
         // Built by instantiating while providing the values per row of the returned pricing data
         const pricingCardOffer = div(
-          { class: 'pricing-card__offer' },
-          span({ class: 'pricing-card__offer-name', innerHTML: Number(pricingRow[currency]).toLocaleString('en-US') }),
+          { class: 'pricing-card-offer' },
+          span({ class: 'pricing-card-offer-name', innerHTML: Number(pricingRow[currency]).toLocaleString('en-US') }),
           div(
-            { class: 'pricing-card__offer-price-container' },
-            span({ class: 'pricing-card__offer-price', innerHTML: currencySymbol + Number(pricingRow[currency]).toLocaleString('en-US') }),
+            { class: 'pricing-card-offer-price-container' },
+            span({ class: 'pricing-card-offer-price', innerHTML: currencySymbol + Number(pricingRow[currency]).toLocaleString('en-US') }),
           ),
         );
         pricingCardOption.append(pricingCardOffer);
       });
-      tabElem.querySelector('.pricing-card__card').append(pricingCardOption);
+      tabElem.querySelector('.pricing-card-card').append(pricingCardOption);
     });
 
     const endNoteElem = div(
       { class: 'end-note' },
       div(
-        { class: 'end-note__content' },
+        { class: 'end-note-content' },
         p({ innerHTML: endNoteContent }),
       ),
     );
@@ -102,22 +102,22 @@ export default async function decorate(block) {
 
   block.innerHTML = `
   <div class="container">
-    <div class="category-grid__group">
+    <div class="category-grid-group">
       <div class="row">
         <div class="col-12 col-lg-3">
-          <div class="category-grid__header">
-            <h2 class="category-grid__header-title">Pricing</h2>
+          <div class="category-grid-header">
+            <h2 class="category-grid-header-title">Pricing</h2>
           </div>
         </div>
         <div class="col-12 col-lg-9">
-          <div class="category-grid__items three-col">
+          <div class="category-grid-items three-col">
             <div class="aem-Grid aem-Grid--12 aem-Grid--default--12  row">
               <div class="productPricingTabs aem-GridColumn aem-GridColumn--default--12">
                 <section id="product-card-tabbed" class="tabs product-card-tabbed">
                   <div class="container">
                     <div class="row">
                       <div class="col-12">
-                        <div role="tablist" aria-label="SMS" class="tabs__tabs">
+                        <div role="tablist" aria-label="SMS" class="tabs-tabs">
                             <!--  Tab button elements populated here while iterating through the returned pricing data-->
                         </div>
                       </div>

--- a/blocks/pricing-grid/pricing-grid.js
+++ b/blocks/pricing-grid/pricing-grid.js
@@ -101,7 +101,7 @@ export default async function decorate(block) {
   const endNoteContent = block.querySelector('h3').innerText;
 
   block.innerHTML = `
-  <div class="container">
+  <div class="container" id="pricing">
     <div class="category-grid-group">
       <div class="row">
         <div class="col-12 col-lg-3">

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -303,7 +303,7 @@ function importTrustPilot(main, document) {
 }
 
 function importQnA(main, document) {
-  const qnas = main.querySelectorAll('h2.faq__title + div.aem-Grid');
+  const qnas = main.querySelectorAll('h2.faq__title + div.aem-grid');
   qnas.forEach((qna) => {
     const faqCells = [['QandA']];
     const questions = qna.querySelectorAll('section.faq');


### PR DESCRIPTION
Pricing grid block necessary for the global-calling-plans page.

Fix #137

Test URLs:
- Before: https://main--vonage--hlxsites.hlx.page/unified-communications/global/global-calling-plans
- After: https://issue-137-pricinggrid--vonage--hlxsites.hlx.page/unified-communications/global/global-calling-plans

Draft available here:
https://issue-137-pricinggrid--vonage--hlxsites.hlx.page/drafts/dgranber/pricing-grid

Notes: 
Pulls pricing data relative to the page housing the component, executes a call for `${window.location.pathname}/pricing/data.json`
The data in the file should have a suitable number of sheets (pricing tier data which for now is just two tiers) and each sheet should have pricing information for 1 or more currencies associated to minute plan values as well as the desired label to display in the pricing grid:

minutes | usd | euro | label |  
-- | -- | -- | -- | --
1,000 | 50 | 50 | Tier 1 minute packs (monthly price) |  

The currency symbol is not necessary as it's manually added as a decoration to the localized numeric display.  

In the block configuration one provides the following attributes:

The two currencies to reference from the source data (based on the column name)
The end note text to display below the pricing grid. 

Everything else is populated in the decoration of the block. 

